### PR TITLE
added staypuft settings category

### DIFF
--- a/app/models/settings/staypuft.rb
+++ b/app/models/settings/staypuft.rb
@@ -1,0 +1,21 @@
+class Setting::Staypuft < ::Setting
+  BLANK_ATTRS << "base_hostgroup"
+
+  def self.load_defaults
+    # Check the table exists
+    return unless super
+
+    # fixme: not sure about the best way to store AR objects in settings.
+    # for now, since we know type, store ID. It might be good to add custom
+    # get/set code to decode the ID value into a hostgroup (which methods to call?)
+    Setting.transaction do
+      [
+       self.set("base_hostgroup", _("The base hostgroup which contains the base provisioning config"), nil)
+      ].compact.each { |s| self.create s.update(:category => "Setting::Staypuft")}
+    end
+
+    true
+
+  end
+
+end


### PR DESCRIPTION
This is needed for storing provisioning data in the installer
for retrieval by the wizard.

Not ready for merge yet. There are some open questions around
how to handle AR references in the settings values which need
to be resolved first
