### PR TITLE
Temporarily disable puppetrun in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
 # enabling puppet run'
-Setting['puppetrun'] = true
+#Setting['puppetrun'] = true


### PR DESCRIPTION
- Caused the seeds to try and create the puppetrun but it requires the module to already exist, or it fails.
