### PR TITLE
second attempt to fix hostgroup ordering for orchestration

### DIFF
--- a/app/lib/actions/staypuft/deployment/deploy.rb
+++ b/app/lib/actions/staypuft/deployment/deploy.rb
@@ -21,8 +21,8 @@ module Actions
         def plan(deployment)
           Type! deployment, ::Staypuft::Deployment
 
-          # already ordered on the child_hostgroups association
-          ordered_hostgroups    = deployment.child_hostgroups
+          ordered_hostgroups    = deployment.child_hostgroups.
+            reorder("staypuft_deployment_role_hostgroups.deploy_order")
 
           plan_action Hostgroup::OrderedDeploy, ordered_hostgroups
         end

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -6,10 +6,10 @@ module Staypuft
     belongs_to :layout
     belongs_to :hostgroup, :dependent => :destroy
 
-    has_many :deployment_role_hostgroups, :dependent => :destroy, :order => "staypuft_deployment_role_hostgroups.deploy_order ASC"
+    has_many :deployment_role_hostgroups, :dependent => :destroy
     has_many :child_hostgroups, :through => :deployment_role_hostgroups, :class_name => 'Hostgroup',
-                                :source => :hostgroup, :order => "staypuft_deployment_role_hostgroups.deploy_order ASC"
-    has_many :roles, :through => :deployment_role_hostgroups, :order => "staypuft_deployment_role_hostgroups.deploy_order ASC"
+                                :source => :hostgroup
+    has_many :roles, :through => :deployment_role_hostgroups
 
     validates  :name, :presence => true, :uniqueness => true
 


### PR DESCRIPTION
Rather than messing with custom sql, this PR just removes the
attempt at ordering child_hostgroups in the association.
Instead, we call .reorder() explicitly in deploy.rb where
we attempt to deploy the hosts.
