### PR TITLE
don't display the ugly auto-generated deployment name: make user choose ...

### DIFF
--- a/app/controllers/staypuft/deployment_steps_controller.rb
+++ b/app/controllers/staypuft/deployment_steps_controller.rb
@@ -42,6 +42,7 @@ module Staypuft
     private
     def get_deployment
       @deployment = Deployment.first
+      @deployment.name = nil if @deployment.name.starts_with?(Deployment::NEW_NAME_PREFIX)
     end
 
     def redirect_to_finish_wizard(options = {})

--- a/app/controllers/staypuft/deployments_controller.rb
+++ b/app/controllers/staypuft/deployments_controller.rb
@@ -11,8 +11,7 @@ module Staypuft
       base_hostgroup = Hostgroup.where(:name => 'base_hostgroup').first or
           raise 'missing base_hostgroup'
 
-      deployment             = Deployment.new(:name => SecureRandom.hex)
-      deployment.description = "This is a deployment"
+      deployment             = Deployment.new(:name => Deployment::NEW_NAME_PREFIX+SecureRandom.hex)
       deployment.layout      = Layout.where(:name       => "Distributed",
                                             :networking => "neutron").first
       deployment_hostgroup   = ::Hostgroup.nest deployment.name, base_hostgroup

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -1,5 +1,8 @@
 module Staypuft
   class Deployment < ActiveRecord::Base
+
+    NEW_NAME_PREFIX="uninitialized_"
+
     attr_accessible :description, :name, :layout_id, :layout
     after_save :update_hostgroup_name
 


### PR DESCRIPTION
...a new one

We auto-generate an ugly name since name is required in the Deployment model
and the wizard requires the object be created prior to showing the 'new' form.
This commit adds a specific "uninitialized deployment" prefix to the auto-generated
name, and the wizard clears it out of the form, requiring the user to enter
a real name on the first step of the wizard.
