### PR TITLE
Fix nonexistent staypuft_deployments params when services have no config...

### DIFF
--- a/app/controllers/staypuft/deployment_steps_controller.rb
+++ b/app/controllers/staypuft/deployment_steps_controller.rb
@@ -34,14 +34,16 @@ module Staypuft
       when :services_configuration
         # Collect services across all deployment's roles
         @services = @deployment.roles(:services).map(&:services).flatten.uniq
-        param_data = params[:staypuft_deployment][:hostgroup_params]
-        diffs = []
-        param_data.each do |hostgroup_id, hostgroup_params|
-          hostgroup = Hostgroup.find(hostgroup_id)
-          hostgroup_params[:puppetclass_params].each do |puppetclass_id, puppetclass_params|
-            puppetclass = Puppetclass.find(puppetclass_id)
-            puppetclass_params.each do |param_name, param_value|
-              hostgroup.set_param_value_if_changed(puppetclass, param_name, param_value)
+        if params[:staypuft_deployment]
+          param_data = params[:staypuft_deployment][:hostgroup_params]
+          diffs = []
+          param_data.each do |hostgroup_id, hostgroup_params|
+            hostgroup = Hostgroup.find(hostgroup_id)
+            hostgroup_params[:puppetclass_params].each do |puppetclass_id, puppetclass_params|
+              puppetclass = Puppetclass.find(puppetclass_id)
+              puppetclass_params.each do |param_name, param_value|
+                hostgroup.set_param_value_if_changed(puppetclass, param_name, param_value)
+              end
             end
           end
         end


### PR DESCRIPTION
...uration

If there is no configuration for any service in step 3,
there will be no params[:staypuft_deployment] present.
This adds test if params[:staypuft_deployment] exists
to deployment_steps_controller when step 3 is submitted.
