### PR TITLE
Fix AR Relation error when deployment deploy is started

### DIFF
--- a/app/lib/actions/staypuft/deployment/deploy.rb
+++ b/app/lib/actions/staypuft/deployment/deploy.rb
@@ -21,7 +21,7 @@ module Actions
           Type! deployment, ::Staypuft::Deployment
 
           ordered_hostgroups = deployment.child_hostgroups.
-              reorder("#{::Staypuft::DeploymentRoleHostgroup.table_name}.deploy_order")
+              reorder("#{::Staypuft::DeploymentRoleHostgroup.table_name}.deploy_order").all
           input.update id: deployment.id, name: deployment.name
 
           plan_action Hostgroup::OrderedDeploy, ordered_hostgroups


### PR DESCRIPTION
I am not 100% sure this solution is correct, there might better method to call on AR relation to get Array. Also note that in further future (Rails 4), '''all''' returns AR relation too instead of array.
