### PR TITLE
Set build flag to true in build task

### DIFF
--- a/app/lib/actions/staypuft/host/build.rb
+++ b/app/lib/actions/staypuft/host/build.rb
@@ -23,6 +23,7 @@ module Actions
 
         def run
           host             = ::Host.find(input[:host_id])
+          host.build       = true
           # return back to hostgroup's environment
           host.environment = nil
           host.save!


### PR DESCRIPTION
Without setting this flag Host do not build on boot.

Working against foreman develop branch, commit: 346b20ee4b7ffa6c4c929c7716c46775f3339705
