### PR TITLE
enable more HA services, and enable HA neutron layout.

### DIFF
--- a/app/assets/stylesheets/staypuft/staypuft.css.scss
+++ b/app/assets/stylesheets/staypuft/staypuft.css.scss
@@ -21,6 +21,7 @@
   height: 300px;
   min-height: 200px;
   margin-right: 10px;
+  overflow: auto;
 }
 
 .nav > li > a.roles_list {

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -62,13 +62,18 @@ module Staypuft
       end
     end
 
-    # If layout networking is set to 'neutron', then set include_neutron on the
-    # hostgroup if it includes the "quickstack::pacemaker::params" puppetclass
+    # If layout networking is set to 'neutron', then set include_neutron and
+    # neutron on the hostgroup if it includes the "quickstack::pacemaker::params"
+    #  puppetclass
     def set_networking_params
       child_hostgroups.each do |the_hostgroup|
         the_hostgroup.puppetclasses.each do |pclass|
           if pclass.class_params.where(:key=> "include_neutron").first          
             the_hostgroup.set_param_value_if_changed(pclass, "include_neutron",
+                                     (layout.networking == 'neutron') ? true : false)
+          end
+          if pclass.class_params.where(:key=> "neutron").first          
+            the_hostgroup.set_param_value_if_changed(pclass, "neutron",
                                      (layout.networking == 'neutron') ? true : false)
           end
         end

--- a/app/models/staypuft/service.rb
+++ b/app/models/staypuft/service.rb
@@ -87,8 +87,8 @@ module Staypuft
                             "ovs_vxlan_udp_port", "qpid_host", "ssl",
                             "tenant_network_type", "tunnel_id_ranges", "verbose"],
       "Neutron-ovs-agent"=> [],
-      "Swift" => ["swift_all_ips", "swift_ext4_device", "swift_local_interface",
-                  "swift_loopback", "swift_ring_server", "swift_shared_secret"]
+      "Swift (node)" => ["swift_all_ips", "swift_ext4_device", "swift_local_interface",
+                         "swift_loopback", "swift_ring_server", "swift_shared_secret"]
 
     }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,7 +148,7 @@ services = {
   :nova_compute       => {:name => "Nova-compute", :class => []},
   :neutron_compute    => {:name => "Neutron-compute", :class => []},
   :neutron_ovs_agent  => {:name => "Neutron-ovs-agent", :class => []},
-  :swift              => {:name => "Swift", :class => []},
+  :swift              => {:name => "Swift (node)", :class => []},
   :ha_controller      => {:name => "HA (Controller)", :class => ["quickstack::openstack_common",
                                                                  "quickstack::pacemaker::common",
                                                                  "quickstack::pacemaker::params"]},
@@ -160,6 +160,10 @@ services = {
   :glance_ha             => {:name => "Glance (HA)", :class => ["quickstack::pacemaker::glance"]},
   :nova_ha               => {:name => "Nova (HA)", :class => ["quickstack::pacemaker::nova"]},
   :cinder_ha             => {:name => "Cinder (HA)", :class => ["quickstack::pacemaker::cinder"]},
+  :swift_ha              => {:name => "Swift (HA)", :class => ["quickstack::pacemaker::swift"]},
+  :horizon_ha            => {:name => "Horizon (HA)", :class => ["quickstack::pacemaker::horizon"]},
+  :mysql_ha              => {:name => "Mysql (HA)", :class => ["quickstack::pacemaker::mysql"]},
+  :neutron_ha            => {:name => "Neutron (HA)", :class => ["quickstack::pacemaker::neutron"]},
   :ha_db_temp            => {:name => "Database (HA -- temp)", :class => ["quickstack::hamysql::singlenodetest"]}
 }
 services.each do |skey, svalue|
@@ -222,14 +226,10 @@ roles = [
      :class=>"quickstack::swift::storage",
      :layouts=>[[:ha_nova, 5], [:ha_neutron, 5], [:non_ha_nova, 5], [:non_ha_neutron, 5]],
      :services=>[:swift]},
-    {:name=>"HA Controller (Nova)",
+    {:name=>"HA Controller",
      :class=>[],
-     :layouts=>[[:ha_nova, 3]],
-     :services=>[:ha_controller, :keystone_ha, :load_balancer_ha, :memcached_ha, :qpid_ha, :glance_ha, :nova_ha, :cinder_ha]},
-    {:name=>"HA Controller (Neutron)",
-     :class=>[],
-     :layouts=>[[:ha_neutron, 2]],
-     :services=>[]},
+     :layouts=>[[:ha_nova, 3], [:ha_neutron, 2]],
+     :services=>[:ha_controller, :keystone_ha, :load_balancer_ha, :memcached_ha, :qpid_ha, :glance_ha, :nova_ha, :cinder_ha, :swift_ha, :horizon_ha, :mysql_ha, :neutron_ha]},
          # this one is temporary -- goes away once db is added back to HA COntroller
     {:name=>"HA Database (temporary)",
      :class=>[],


### PR DESCRIPTION
This enables swift, mysql, horizon, and neutron services for HA.

Note that:
1) you probably need to drop your db before re-running puppetclass import
and rake db:seed, since I changed the name of the HA controller, and
seeds.rb isn't quite smart enough to catch that it's a rename rather than an addition
Alternatively, go into rails console and delete all Staypuft::Role objects and
Staypuft::Layout objects prior to re-running db:seed
2) after this change, we probably need to remove the separate db node. To test this
you can probably just not add any hosts to the database role, but we should probably
remove that role entirely once this change is merged.
