### PR TITLE
Fix version comparison with RC strings (e.g. 1.5.0-RC1)

### DIFF
--- a/app/models/staypuft/concerns/hostgroup_extensions.rb
+++ b/app/models/staypuft/concerns/hostgroup_extensions.rb
@@ -54,7 +54,7 @@ module Staypuft::Concerns::HostgroupExtensions
     end
   end
 
-  Gem::Version.new(SETTINGS[:version].to_s.gsub(/-develop$/, '')) < Gem::Version.new('1.5') and
+  Gem::Version.new(SETTINGS[:version].notag) < Gem::Version.new('1.5') and
       Rails.logger.warn 'Foreman 1.5 is required for nesting of Hostgroups to work properly,' +
                             "please upgrade or expect failures.\n#{__FILE__}:#{__LINE__}"
 end


### PR DESCRIPTION
Fixes this stack trace using Foreman 1.5.0-RC1 or the 1.5-stable branch:

<pre>
[root@foreman01 ~]# foreman-rake db:migrate --trace
** Invoke db:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
Malformed version number string 1.5.0-RC1
/opt/rh/ruby193/root/usr/share/rubygems/rubygems/version.rb:187:in `initialize'
/opt/rh/ruby193/root/usr/share/gems/gems/staypuft-0.0.9/app/models/staypuft/concerns/hostgroup_extensions.rb:57:in `new'
/opt/rh/ruby193/root/usr/share/gems/gems/staypuft-0.0.9/app/models/staypuft/concerns/hostgroup_extensions.rb:57:in `<module:HostgroupExtensions>'
/opt/rh/ruby193/root/usr/share/gems/gems/staypuft-0.0.9/app/models/staypuft/concerns/hostgroup_extensions.rb:1:in `<top (required)>'
</pre>


Remember to re-tag any new release to fix this issue into the foreman-plugins-1.5-\* tags so it's accessible for 1.5 users.
