### PR TITLE
Reset host token

### DIFF
--- a/app/lib/actions/staypuft/host/build.rb
+++ b/app/lib/actions/staypuft/host/build.rb
@@ -25,6 +25,7 @@ module Actions
           host             = ::Host.find(input[:host_id])
           # return back to hostgroup's environment
           host.environment = nil
+          host.set_token
           host.save!
           host.send :setTFTP
           restart(host)


### PR DESCRIPTION
Foreman sets the expire provisioning token on a host machine when host
machine build flag is set, not when the host is actually provisioned.
In Staypuft we delay the provisioning of some machines until later in
the orchestration sequence.  This may result in token expiry.  This
patch resets the host expire token during the Staypuft host build task.
