### PR TITLE
Add deployment form_step for condition validations

### DIFF
--- a/app/controllers/staypuft/deployment_steps_controller.rb
+++ b/app/controllers/staypuft/deployment_steps_controller.rb
@@ -17,24 +17,23 @@ module Staypuft
     end
 
     def update
-      # TODO(jtomasek):
-      # in model we need to conditionally validate based on the step eg:
-      # validates_presence_of :some_attribute, :if => :on_deployment_settings_step?
-      # see wicked wiki for more info
-
       case step
       when :deployment_settings
         @layouts = ordered_layouts
 
         Deployment.transaction do
+          @deployment.form_step = Deployment::STEP_SETTINGS unless @deployment.form_complete?
           @deployment.update_attributes(params[:staypuft_deployment])
           @deployment.update_hostgroup_list
           @deployment.set_networking_params
         end
+      when :services_selection
+        @deployment.form_step = Deployment::STEP_SELECTION unless @deployment.form_complete?
       when :services_configuration
         # Collect services across all deployment's roles
         @services = @deployment.services.order(:name)
         if params[:staypuft_deployment]
+          @deployment.form_step = Deployment::STEP_CONFIGURATION unless @deployment.form_complete?
           param_data = params[:staypuft_deployment][:hostgroup_params]
           diffs      = []
           param_data.each do |hostgroup_id, hostgroup_params|

--- a/db/migrate/20140507103716_add_form_step_to_staypuft_deployment.rb
+++ b/db/migrate/20140507103716_add_form_step_to_staypuft_deployment.rb
@@ -1,0 +1,5 @@
+class AddFormStepToStaypuftDeployment < ActiveRecord::Migration
+  def change
+    add_column :staypuft_deployments, :form_step, :string
+  end
+end


### PR DESCRIPTION
This patch adds an extra field form_step to the deployment model.  This
is to be used for conditional validations.  Validations can now take
place in a aggregational model, where each step in the deployment
creation form has it's own validations.  This method is taken directly
from the wicked rubygem wiki.

Note: Run rake db:migrate
