### PR TITLE
Disable multiple deploy submissions on deploy form

### DIFF
--- a/app/views/staypuft/deployments/show.html.erb
+++ b/app/views/staypuft/deployments/show.html.erb
@@ -146,7 +146,11 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal"><%= _("Cancel") %></button>
-        <%= display_link_if_authorized(_("Deploy"), hash_for_deploy_deployment_path, :class => 'btn btn-primary') %>
+        <%= display_link_if_authorized(_("Deploy"),
+                                       hash_for_deploy_deployment_path,
+                                       :class => 'btn btn-primary',
+                                       :method => :post,
+                                       :data => { :disable_with => _("Deploying...")}) %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
         post 'associate_host'
       end
       member do
-        get 'deploy'
+        post 'deploy'
         get 'populate'
         get 'summary'
       end


### PR DESCRIPTION
This patch disables the deploy button on the deploy form after it has
been clicked once.  This prevents multiple submits being sent by the
same form.  The patch also changes the deploy route to POST to avoid the
user accidently submitting deploy when navigating to /deploy.
