### PR TITLE
Renamed 'Assign' button to 'Assign / Unassign'

### DIFF
--- a/app/views/staypuft/deployments/show.html.erb
+++ b/app/views/staypuft/deployments/show.html.erb
@@ -76,7 +76,7 @@
         <% if child_hostgroup.own_and_free_hosts.present? %>
           <%= form_tag(associate_host_deployments_path, class: 'form-horizontal well association') do |f| %>
             <p>
-              <%= submit_tag _("Assign"), :class => "btn btn-primary btn-sm" %>
+              <%= submit_tag _("Assign / Unassign"), :class => "btn btn-primary btn-sm" %>
             </p>
             <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
             <table class="table table-bordered table-striped table-condensed">


### PR DESCRIPTION
The assign button on the deployment page actually removes hosts from a
hostgroup as well as adding them.  This behaviour is not obvious since
the button is named 'Assign' which suggests add only.  Renaming to make
the behaviour more obvious.
