### PR TITLE
Maintain hostgroup selection after assign host

### DIFF
--- a/app/controllers/staypuft/deployments_controller.rb
+++ b/app/controllers/staypuft/deployments_controller.rb
@@ -29,6 +29,8 @@ module Staypuft
 
     def show
       @deployment = Deployment.find(params[:id])
+      @hostgroup = ::Hostgroup.find_by_id(params[:hostgroup_id]) ||
+                                 @deployment.child_hostgroups.deploy_order.first
     end
 
     def summary
@@ -82,7 +84,8 @@ module Staypuft
         host.save!
       end
 
-      redirect_to deployment_path(id: ::Staypuft::Deployment.first)
+      redirect_to show_with_hostgroup_selected_deployment_path(:id => Staypuft::Deployment.first,
+                                                                :hostgroup_id => hostgroup)
     end
 
     private

--- a/app/views/staypuft/deployments/show.html.erb
+++ b/app/views/staypuft/deployments/show.html.erb
@@ -48,7 +48,7 @@
   <ul class="nav nav-pills nav-stacked col-md-4" data-tabs="pills">
     <h3><%= _("Host Groups") %></h3>
     <% @deployment.child_hostgroups.deploy_order.each_with_index do |child_hostgroup, i| %>
-      <li class="<%= 'active' if i == 0 %>">
+      <li class="<%= 'active' if @hostgroup == child_hostgroup %>">
         <a href="#<%= child_hostgroup.name.parameterize.underscore %>" data-toggle="tab" class="roles_list">
           <div class="col-xs-2 text-center">
             <i class="glyphicon glyphicon-ok"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
         post 'associate_host'
       end
       member do
+        match '/hostgroup/:hostgroup_id',
+              :to => 'deployments#show',
+              :as => :show_with_hostgroup_selected, :method => :get
         post 'deploy'
         get 'populate'
         get 'summary'


### PR DESCRIPTION
This patch updates the deployment show page to maintain the selected
HostGroup after a the user selects the "Assign / Unassign" button.
Previous behaviour reset the selected Hostgroup to the first Hostgroup
listed.
