### PR TITLE
fixes BZ1107794: changed puppetclass name to quickstack::storage_backend...

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -147,7 +147,7 @@ services     = {
     :neutron_controller => { :name => 'Neutron (Controller)', :class => [] },
     :non_ha_glance      => { :name => 'Glance (non-HA)', :class => [] },
     :cinder_controller  => { :name => 'Cinder (controller)', :class => [] },
-    :cinder_node        => { :name => 'Cinder (node)', :class => ['quickstack::storage_backend::lvm_cinder'] },
+    :cinder_node        => { :name => 'Cinder (node)', :class => ['quickstack::storage_backend::cinder'] },
     :heat               => { :name => 'Heat', :class => [] },
     :ceilometer         => { :name => 'Ceilometer', :class => [] },
     :neutron_networker  => { :name => 'Neutron Networker', :class => ['quickstack::neutron::networker'] },


### PR DESCRIPTION
...::cinder

https://bugzilla.redhat.com/show_bug.cgi?id=1107794
