### PR TITLE
fix case matching issues in mac addresses

### DIFF
--- a/app/controllers/staypuft/deployments_controller.rb
+++ b/app/controllers/staypuft/deployments_controller.rb
@@ -130,7 +130,7 @@ module Staypuft
 
         interface = hosts_facts.
             includes(:fact_name).
-            where(value: discovery_bootif.value).
+            where(value: discovery_bootif.value.upcase).
             find { |v| v.fact_name.name =~ /^macaddress_.*$/ }.
             fact_name.name.split('_').last
 


### PR DESCRIPTION
this forces mac addresses to lower case when trying to
match discovery_bootif to a macaddress_\* fact.
