### PR TITLE
Fixes #1110542 Set deployed/active hosts correctly

### DIFF
--- a/app/models/staypuft/concerns/host_open_stack_affiliation.rb
+++ b/app/models/staypuft/concerns/host_open_stack_affiliation.rb
@@ -17,10 +17,16 @@ module Staypuft
         has_one :deployment, through: :hostgroup
       end
 
+
       def open_stack_deployed?
+        !deployment.nil? && !deployment.in_progress? &&
+        open_stack_environment_set? && open_stack_assigned?
+      end
+
+      def open_stack_environment_set?
         open_stack_assigned? &&
-            respond_to?(:environment) &&
-            environment != Environment.get_discovery
+        respond_to?(:environment) &&
+        environment != Environment.get_discovery
       end
 
       def open_stack_assigned?

--- a/app/models/staypuft/concerns/hostgroup_extensions.rb
+++ b/app/models/staypuft/concerns/hostgroup_extensions.rb
@@ -53,6 +53,19 @@ module Staypuft::Concerns::HostgroupExtensions
     Host::Base.where('hostgroup_id = ? OR hostgroup_id IS NULL', id)
   end
 
+  # Returns all hosts associated with this hostgroup with the openstack
+  # deployment environment set.  These can be filtered based by setting
+  # errors=true or errors=false to return only the hosts  with no errors or
+  # with errors respectively.
+  def openstack_hosts(errors=nil)
+    oshosts = hosts.select { |h| h.open_stack_environment_set? }
+
+    unless errors.nil?
+      oshosts.select! { |h| (!errors ^ h.error?) }
+    end
+    oshosts
+  end
+
   module ClassMethods
     def get_base_hostgroup
       Hostgroup.where(:name => Setting[:base_hostgroup]).first or raise 'missing base_hostgroup'

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -75,6 +75,22 @@ module Staypuft
 
     extend AttributeParamStorage
 
+    # Returns a list of hosts that are currently being deployed.
+    def in_progress_hosts(hostgroup)
+      return in_progress? ? hostgroup.openstack_hosts : {}
+    end
+
+    # Helper method for checking whether this deployment is in progress or not.
+    def in_progress?
+      ForemanTasks::Lock.locked? self, nil
+    end
+
+    # Returns all deployed hosts with no errors (default behaviour).  Set
+    # errors=true to return all deployed hosts that have errors
+    def deployed_hosts(hostgroup, errors=false)
+      in_progress? ? {} : hostgroup.openstack_hosts(errors)
+    end
+
     def self.param_scope
       'deployment'
     end

--- a/app/views/staypuft/deployments/show.html.erb
+++ b/app/views/staypuft/deployments/show.html.erb
@@ -51,7 +51,7 @@
     </div>
   <% end %>
 
-  <% if ForemanTasks::Lock.locked? @deployment, nil %>
+  <% if @deployment.in_progress? %>
     <%= display_link_if_authorized(
             _('Deploy in progress'),
             hash_for_foreman_tasks_task_path(id: ForemanTasks::Lock.colliding_locks(@deployment, nil).first.task.id),
@@ -76,15 +76,15 @@
         <a href="#<%= child_hostgroup.name.parameterize.underscore %>" data-toggle="tab" class="roles_list">
           <div class="col-xs-2 text-center">
             <i class="glyphicon glyphicon-ok"></i>
-            <span><%= child_hostgroup.hosts.select { |h| h.open_stack_deployed? && !h.error? }.count %></span>
+            <span><%= @deployment.deployed_hosts(child_hostgroup).count %></span>
           </div>
           <div class="col-xs-2 text-center">
             <i class="glyphicon glyphicon-warning-sign"></i>
-            <span><%= child_hostgroup.hosts.select { |h| h.open_stack_deployed? && h.error? }.count %></span>
+            <span><%= @deployment.deployed_hosts(child_hostgroup, true).count %></span>
           </div>
           <div class="col-xs-2 text-center">
             <i class="glyphicon glyphicon-time"></i>
-            <span><%= child_hostgroup.hosts.select { |h| !h.open_stack_deployed? }.count %></span>
+            <span><%= @deployment.in_progress_hosts(child_hostgroup).count %></span>
           </div>
           <div class="col-xs-6"><%= child_hostgroup.name %></div>
           <span class="clearfix"></span>
@@ -121,7 +121,7 @@
                                   ('deployed' if host.open_stack_deployed?)
                                  ].compact.join(' ') %>">
                     <td class="ca">
-                      <% disabled = ForemanTasks::Lock.locked?(@deployment, nil) && host.open_stack_deployed? %>
+                      <% disabled = @deployment.in_progress? && host.open_stack_environment_set? %>
                       <%= check_box_tag 'host_ids[]',
                                         host.id,
                                         child_hostgroup.host_ids.include?(host.id),


### PR DESCRIPTION
Updates the host group table on the deployment show page to calculate
the deployed successfully / deployed with errors / deploying hosts total
for each host group.  Since all hosts are not deployed until after the
deployment has finished.  The update checks for the lock on the deployed
to determine whether this deployment is complete or not.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1110542
