### PR TITLE
Rework the hosts assignment page

### DIFF
--- a/app/assets/javascripts/staypuft/staypuft.js
+++ b/app/assets/javascripts/staypuft/staypuft.js
@@ -24,7 +24,21 @@ $(function () {
     var tr = $(this).closest("tr");
     tr.toggleClass("info", this.checked);
     if (tr.hasClass("deployed")) {
-      tr.toggleClass("danger", !this.checked);
+      tr.toggleClass("danger", this.checked);
     }
   });
+
+  // Workaround to properly activate and deactivate tabs in tabbed_side_nav_table
+  // Should be probably done properly by extending Bootstrap Tab
+  $(".tabbed_side_nav_table").on('click.bs.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', function (e) {
+    e.preventDefault();
+    $(this).closest('ul').find('.activated').removeClass('activated');
+    $(this).addClass("activated");
+    $(this).closest('li').addClass('activated');
+  });
+
+  $('.tabbed_side_nav_table').on('click', 'button.close', function() {
+    $(this).closest('.tab-pane.active').removeClass('active');
+    $(this).closest('.tabbed_side_nav_table').find('.activated').removeClass('activated');
+  })
 });

--- a/app/assets/stylesheets/staypuft/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/staypuft/bootstrap_and_overrides.css.scss
@@ -86,12 +86,12 @@
 }
 
 .tabbed_side_nav_table{
-  .nav.nav-pills.nav-stacked {
+  .nav {
     padding-top: 5px;
     padding-right: 4px;
-    & > li.active {
+    & > li.activated {
       z-index: 1;
-      & > a:after, & > a:before {
+      &:after, &:before {
         content: "";
         position: absolute;
         top: 0px;
@@ -103,11 +103,49 @@
         border-color: rgba(238, 238, 238, 0) rgb(238, 238, 238) rgba(238, 238, 238, 0) rgba(238, 238, 238, 0);
         -webkit-transform:rotate(360deg);
       }
-      & > a:before {
+      &:before {
         border-width: 21px 16px 21px 0;
         top: -1px;
         right: -9px;
         border-right-color: rgb(217, 217, 217);
+      }
+    }
+    li {
+      border: 1px solid rgb(227, 227, 227);
+      height: 42px;
+      margin-bottom: 3px;
+      border-radius: 4px;
+      line-height: 40px;
+      box-sizing: border-box;
+      padding: 0;
+      text-align: center;
+      &:hover, &.activated {
+        background: rgb(238, 238, 238);
+      }
+      & > div {
+        padding: 0;
+        div.group_name {
+          text-align: left;
+          padding: 0 8px;
+        }
+        &:not(:first-child) {
+          border-left: 1px solid rgb(227, 227, 227);
+        }
+        &:last-child > a {
+          border-top-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+        }
+        & > a {
+          box-sizing: border-box;
+          display: block;
+          &.activated {
+            background: $brand-primary;
+            color: white;
+          }
+          &.disabled {
+            color: $btn-link-disabled-color;
+          }
+        }
       }
     }
   }

--- a/app/assets/stylesheets/staypuft/staypuft.css.scss
+++ b/app/assets/stylesheets/staypuft/staypuft.css.scss
@@ -24,17 +24,13 @@
   overflow: auto;
 }
 
-.nav > li > a.roles_list {
-  padding: 0;
-  border: 1px solid #ddd;
-  & > div {
-    padding: 10px;
-    &:not(:first-child) {
-      border-left: 1px solid #ddd;
-    }
-  }
-}
-
 .association.well {
   min-height: 500px;
+  margin-top: 50px;
+  h4{
+    margin: 6px 0 6px 0;
+    &.pull-left {
+      margin-left: 10px;
+    }
+  }
 }

--- a/app/models/staypuft/concerns/hostgroup_extensions.rb
+++ b/app/models/staypuft/concerns/hostgroup_extensions.rb
@@ -48,9 +48,8 @@ module Staypuft::Concerns::HostgroupExtensions
     end
   end
 
-  def own_and_free_hosts
-    # TODO update to Discovered only?
-    Host::Base.where('hostgroup_id = ? OR hostgroup_id IS NULL', id)
+  def free_hosts
+    Host::Base.where('hostgroup_id IS NULL')
   end
 
   module ClassMethods

--- a/app/views/staypuft/deployments/.fuse_hidden000000fd00000001
+++ b/app/views/staypuft/deployments/.fuse_hidden000000fd00000001
@@ -1,0 +1,60 @@
+<div class="tab-pane" id="<%= child_hostgroup.name.parameterize.underscore %>_assigned_hosts">
+  <% if child_hostgroup.hosts.present? %>
+    <%= form_tag(unassign_host_deployment_path(id: deployment), class: 'form-horizontal well association') do |f| %>
+      <%= submit_tag _("Unassign Hosts"), :class => "btn btn-primary btn-sm pull-left" %>
+      <h4 class="pull-left"><%= _("Assigned Hosts") %></h4>
+      <button type="button" class="close" aria-hidden="true">×</button>
+      <p class="clearfix"></p>
+      <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th class="ca">
+              <%= check_box_tag :check_all %>
+            </th>
+            <th><%= sort :name, :as => _('Name') %></th>
+            <th class="hidden-s hidden-xs"><%= _('Deployed?') %></th>
+            <th class="hidden-s hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% child_hostgroup.hosts.each do |host| %>
+            <% disabled = ForemanTasks::Lock.locked?(deployment, nil) && host.open_stack_deployed? %>
+            <tr class="<%= ['checkbox_highlight',
+                            ('deployed' if disabled)
+                           ].compact.join(' ') %>">
+              <td class="ca">
+                <%= check_box_tag 'host_ids[]',
+                                  host.id,
+                                  false,
+                                  id:       "host_ids_#{host.id}",
+                                  disabled: disabled %>
+                <%= hidden_field_tag 'host_ids[]', host.id if disabled %>
+              </td>
+              <td class="ellipsis">
+               <%= host_label(host) %>
+              </td>
+              <td class="hidden-s hidden-xs">
+                <% if host.open_stack_deployed? %>
+                  <span class="glyphicon glyphicon-cloud-upload"></span>
+                <% else %>
+                  <span class="glyphicon glyphicon-minus"></span>
+                <% end %>
+              </td>
+              <td class="hidden-s hidden-xs"><%= host.ip %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% else %>
+    <div class="well association">
+      <button type="button" class="close pull-right" aria-hidden="true">×</button>
+      <h4><%= _("Assigned Hosts") %></h4>
+      <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-warning-sign">&nbsp;</span>
+        <%= _("No hosts were assigned to this group yet.") %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/staypuft/deployments/_assigned_hosts_table.html.erb
+++ b/app/views/staypuft/deployments/_assigned_hosts_table.html.erb
@@ -1,0 +1,60 @@
+<div class="tab-pane" id="<%= child_hostgroup.name.parameterize.underscore %>_assigned_hosts">
+  <% if child_hostgroup.hosts.present? %>
+    <%= form_tag(unassign_host_deployment_path(id: deployment), class: 'form-horizontal well association') do |f| %>
+      <%= submit_tag _("Unassign Hosts"), :class => "btn btn-primary btn-sm pull-left" %>
+      <h4 class="pull-left"><%= _("Assigned Hosts") %></h4>
+      <button type="button" class="close" aria-hidden="true">×</button>
+      <p class="clearfix"></p>
+      <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th class="ca">
+              <%= check_box_tag :check_all %>
+            </th>
+            <th><%= sort :name, :as => _('Name') %></th>
+            <th class="hidden-s hidden-xs"><%= _('Deploying?') %></th>
+            <th class="hidden-s hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% child_hostgroup.hosts.each do |host| %>
+            <% disabled = ForemanTasks::Lock.locked?(deployment, nil) && host.open_stack_deployed? %>
+            <tr class="<%= ['checkbox_highlight',
+                            ('deploying' if disabled)
+                           ].compact.join(' ') %>">
+              <td class="ca">
+                <%= check_box_tag 'host_ids[]',
+                                  host.id,
+                                  false,
+                                  id:       "host_ids_#{host.id}",
+                                  disabled: disabled %>
+                <%= hidden_field_tag 'host_ids[]', host.id if disabled %>
+              </td>
+              <td class="ellipsis">
+               <%= host_label(host) %>
+              </td>
+              <td class="hidden-s hidden-xs">
+                <% if disabled %>
+                  <span class="glyphicon glyphicon-cloud-upload"></span>
+                <% else %>
+                  <span class="glyphicon glyphicon-minus"></span>
+                <% end %>
+              </td>
+              <td class="hidden-s hidden-xs"><%= host.ip %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% else %>
+    <div class="well association">
+      <button type="button" class="close pull-right" aria-hidden="true">×</button>
+      <h4><%= _("Assigned Hosts") %></h4>
+      <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-warning-sign">&nbsp;</span>
+        <%= _("No hosts were assigned to this group yet.") %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/staypuft/deployments/_deployed_hosts_table.html.erb
+++ b/app/views/staypuft/deployments/_deployed_hosts_table.html.erb
@@ -1,0 +1,51 @@
+<div class="tab-pane" id="<%= child_hostgroup.name.parameterize.underscore %>_deployed_hosts">
+  <% if child_hostgroup.hosts.select { |h| !ForemanTasks::Lock.locked?(deployment, nil) && h.open_stack_deployed? }.present? %>
+    <%= form_tag(unassign_host_deployment_path(id: deployment), class: 'form-horizontal well association') do |f| %>
+      <%= submit_tag _("Unassign Hosts"),
+          :class => "btn btn-danger btn-sm pull-left",
+          :'data-toggle' => "tooltip",
+          :'data-placement' => "right",
+          :title => _("Unassigning deployed hosts may lead to unexpected problems.") %>
+      <h4 class="pull-left"><%= _("Deployed Hosts") %></h4>
+      <button type="button" class="close" aria-hidden="true">×</button>
+      <p class="clearfix"></p>
+      <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th class="ca">
+              <%= check_box_tag :check_all %>
+            </th>
+            <th><%= sort :name, :as => _('Name') %></th>
+            <th class="hidden-s hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% child_hostgroup.hosts.select{ |h| !ForemanTasks::Lock.locked?(deployment, nil) && h.open_stack_deployed? }.each do |host| %>
+            <tr class="checkbox_highlight deployed">
+              <td class="ca">
+                <%= check_box_tag 'host_ids[]',
+                                  host.id,
+                                  false,
+                                  id:       "host_ids_#{host.id}" %>
+              </td>
+              <td class="ellipsis">
+               <%= host_label(host) %>
+              </td>
+              <td class="hidden-s hidden-xs"><%= host.ip %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% else %>
+    <div class="well association">
+      <button type="button" class="close pull-right" aria-hidden="true">×</button>
+      <h4><%= _("Deployed Hosts") %></h4>
+      <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-warning-sign">&nbsp;</span>
+        <%= _("No hosts from this group have been deployed yet.") %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/staypuft/deployments/_free_hosts_table.html.erb
+++ b/app/views/staypuft/deployments/_free_hosts_table.html.erb
@@ -1,0 +1,47 @@
+<div class="tab-pane" id="<%= child_hostgroup.name.parameterize.underscore %>_free_hosts">
+  <% if child_hostgroup.free_hosts.present? %>
+    <%= form_tag(associate_host_deployment_path(id: deployment), class: 'form-horizontal well association') do |f| %>
+      <%= submit_tag _("Assign Hosts"), :class => "btn btn-primary btn-sm pull-left" %>
+      <h4 class="pull-left"><%= _("Free Hosts") %></h4>
+      <button type="button" class="close" aria-hidden="true">×</button>
+      <p class="clearfix"></p>
+      <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th class="ca">
+              <%= check_box_tag :check_all %>
+            </th>
+            <th><%= sort :name, :as => _('Name') %></th>
+            <th class="hidden-s hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% child_hostgroup.free_hosts.each do |host| %>
+            <tr class="checkbox_highlight">
+              <td class="ca">
+                <%= check_box_tag 'host_ids[]',
+                                  host.id,
+                                  child_hostgroup.host_ids.include?(host.id),
+                                  id:       "host_ids_#{host.id}" %>
+              </td>
+              <td class="ellipsis">
+               <%= host_label(host) %>
+              </td>
+              <td class="hidden-s hidden-xs"><%= host.ip %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% else %>
+    <div class="well association">
+      <button type="button" class="close pull-right" aria-hidden="true">×</button>
+      <h4><%= _("Free Hosts") %></h4>
+      <div class="alert alert-warning">
+        <span class="glyphicon glyphicon-warning-sign">&nbsp;</span>
+        <%= _("All available hosts have been already assigned.") %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/staypuft/deployments/show.html.erb
+++ b/app/views/staypuft/deployments/show.html.erb
@@ -69,91 +69,52 @@
 <% end %>
 
 <div class="row tabbed_side_nav_table">
-  <ul class="nav nav-pills nav-stacked col-md-4" data-tabs="pills">
+  <ul class="nav col-md-4">
     <h3><%= _("Host Groups") %></h3>
     <% @deployment.child_hostgroups.deploy_order.each_with_index do |child_hostgroup, i| %>
-      <li class="<%= 'active' if @hostgroup == child_hostgroup %>">
-        <a href="#<%= child_hostgroup.name.parameterize.underscore %>" data-toggle="tab" class="roles_list">
-          <div class="col-xs-2 text-center">
-            <i class="glyphicon glyphicon-ok"></i>
-            <span><%= child_hostgroup.hosts.select { |h| h.open_stack_deployed? && !h.error? }.count %></span>
+      <li>
+        <div class="col-xs-2">
+          <% if child_hostgroup.hosts.select { |h| !ForemanTasks::Lock.locked?(@deployment, nil) && h.open_stack_deployed? }.count > 0 %>
+            <a href="#<%= child_hostgroup.name.parameterize.underscore %>_deployed_hosts" data-toggle="tab" class="roles_list">
+              <span><%= child_hostgroup.hosts.select { |h| !ForemanTasks::Lock.locked?(@deployment, nil) && h.open_stack_deployed? }.count %></span>
+            </a>
+          <% else %>
+            <span><%= child_hostgroup.hosts.select { |h| !ForemanTasks::Lock.locked?(@deployment, nil) && h.open_stack_deployed? }.count %></span>
+          <% end %>
+        </div>
+        <div class="col-xs-6">
+          <div class="group_name">
+            <%= child_hostgroup.name %>
           </div>
-          <div class="col-xs-2 text-center">
-            <i class="glyphicon glyphicon-warning-sign"></i>
-            <span><%= child_hostgroup.hosts.select { |h| h.open_stack_deployed? && h.error? }.count %></span>
-          </div>
-          <div class="col-xs-2 text-center">
-            <i class="glyphicon glyphicon-time"></i>
-            <span><%= child_hostgroup.hosts.select { |h| !h.open_stack_deployed? }.count %></span>
-          </div>
-          <div class="col-xs-6"><%= child_hostgroup.name %></div>
-          <span class="clearfix"></span>
-        </a>
+        </div>
+        <div class="col-xs-2">
+          <% if child_hostgroup.hosts.select { |h| !(!ForemanTasks::Lock.locked?(@deployment, nil) && h.open_stack_deployed?) }.count > 0 %>
+            <a href="#<%= child_hostgroup.name.parameterize.underscore %>_assigned_hosts" data-toggle="tab" class="roles_list">
+              <i class="glyphicon glyphicon-time"></i>
+              <span><%= child_hostgroup.hosts.select { |h| !(!ForemanTasks::Lock.locked?(@deployment, nil) && h.open_stack_deployed?) }.count %></span>
+            </a>
+          <% end %>
+        </div>
+        <div class="col-xs-2">
+          <a href="#<%= child_hostgroup.name.parameterize.underscore %>_free_hosts" data-toggle="tab" class="roles_list">
+            <i class="glyphicon glyphicon-plus"></i>
+          </a>
+        </div>
       </li>
     <% end %>
   </ul>
 
   <div class="tab-content col-md-8">
     <% @deployment.child_hostgroups.deploy_order.each_with_index do |child_hostgroup, i| %>
-      <div class="tab-pane <%= 'active' if @hostgroup == child_hostgroup %>" id="<%= child_hostgroup.name.parameterize.underscore %>">
-        <h3><%= _("Hosts") %></h3>
-        <% if child_hostgroup.own_and_free_hosts.present? %>
-          <%= form_tag(associate_host_deployment_path(id: @deployment), class: 'form-horizontal well association') do |f| %>
-            <p>
-              <%= submit_tag _("Assign / Unassign"), :class => "btn btn-primary btn-sm" %>
-            </p>
-            <%= hidden_field_tag :hostgroup_id, child_hostgroup.id %>
-            <table class="table table-bordered table-striped table-condensed">
-              <thead>
-                <tr>
-                  <th class="ca">
-                    <%= check_box_tag :check_all %>
-                  </th>
-                  <th><%= sort :name, :as => _('Name') %></th>
-                  <th class="hidden-s hidden-xs"><%= _('Deployed?') %></th>
-                  <th class="hidden-s hidden-xs"><%= sort :ip, :as => _('IP Address') %></th>
-                </tr>
-              </thead>
-              <tbody>
-                <% child_hostgroup.own_and_free_hosts.each do |host| %>
-                  <tr class="<%= ['checkbox_highlight',
-                                  ('success' if child_hostgroup.host_ids.include?(host.id)),
-                                  ('deployed' if host.open_stack_deployed?)
-                                 ].compact.join(' ') %>">
-                    <td class="ca">
-                      <% disabled = ForemanTasks::Lock.locked?(@deployment, nil) && host.open_stack_deployed? %>
-                      <%= check_box_tag 'host_ids[]',
-                                        host.id,
-                                        child_hostgroup.host_ids.include?(host.id),
-                                        id:       "host_ids_#{host.id}",
-                                        disabled: disabled %>
-                      <%= hidden_field_tag 'host_ids[]', host.id if disabled %>
-                    </td>
-                    <td class="ellipsis">
-                     <%= host_label(host) %>
-                    </td>
-                    <td class="hidden-s hidden-xs">
-                      <% if host.open_stack_deployed? %>
-                        <span class="glyphicon glyphicon-cloud"></span>
-                      <% else %>
-                        <span class="glyphicon glyphicon-minus"></span>
-                      <% end %>
-                    </td>
-                    <td class="hidden-s hidden-xs"><%= host.ip %></td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          <% end %>
-        <% else %>
-          <div class="well association">
-            <div class="alert alert-warning">
-              <span class="glyphicon glyphicon-warning-sign">&nbsp;</span>
-              <%= _("All available hosts have been already assigned.") %>
-            </div>
-          </div>
-        <% end %>
-      </div>
+      <%= render :partial => "free_hosts_table", :locals => { :deployment => @deployment,
+                                                              :hostgroup => @hostgroup,
+                                                              :child_hostgroup => child_hostgroup } %>
+      <%= render :partial => "assigned_hosts_table", :locals => { :deployment => @deployment,
+                                                                  :hostgroup => @hostgroup,
+                                                                  :child_hostgroup => child_hostgroup } %>
+      <%= render :partial => "deployed_hosts_table", :locals => { :deployment => @deployment,
+                                                                  :hostgroup => @hostgroup,
+                                                                  :child_hostgroup => child_hostgroup } %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
         get 'populate'
         get 'summary'
         post 'associate_host'
+        post 'unassign_host'
         get 'export_config'
         post 'import_config'
       end


### PR DESCRIPTION
Update table design for Deployment Roles according to wireframes (page 26)
Prevent table of hosts to be always visible
Refine "assigning hosts" workflow (page 7-11)
Refine "unassigning hosts" workflow (page 12-16)
Allow user to see deployed hosts for each role (page 26, note #6)
Enable user to close hosts table
