### PR TITLE
forces to use the staypuft controller

### DIFF
--- a/app/controllers/staypuft/deployments_controller.rb
+++ b/app/controllers/staypuft/deployments_controller.rb
@@ -1,5 +1,5 @@
 module Staypuft
-  class DeploymentsController < ApplicationController
+  class DeploymentsController < Staypuft::ApplicationController
     include Foreman::Controller::AutoCompleteSearch
 
     def index

--- a/app/controllers/staypuft/steps_controller.rb
+++ b/app/controllers/staypuft/steps_controller.rb
@@ -1,5 +1,5 @@
 module Staypuft
-  class StepsController < ApplicationController
+  class StepsController < Staypuft::ApplicationController
     include Wicked::Wizard
     steps :deployment_settings, :services_selection, :services_configuration
 


### PR DESCRIPTION
it seems like the load order might have an impact on the controller being used as a parent.

some partial info from http://stackoverflow.com/questions/10042348/rails-3-2-engine-layouts
