### PR TITLE
Fix the 'no kickstart' problem caused by safe mode

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -163,16 +163,16 @@ module Staypuft
 
     def functional_dependencies
       amqp_provider               = '<%= @host.deployment.amqp_provider %>'
-      neutron                     = '<%= @host.deployment.networking == Staypuft::Deployment::Networking::NEUTRON %>'
+      neutron                     = '<%= @host.deployment.neutron_networking? %>'
 
       # Nova
       network_manager             = '<%= @host.deployment.nova.network_manager %>'
       # multi_host handled inline, since it's two separate static values 'true' and 'True'
-      network_overrides           = '<%= @host.deployment.nova.network_overrides.to_yaml %>'
+      network_overrides           = '<%= @host.deployment.nova.network_overrides %>'
       # TODO: num_networks should be calculated based on a specified VLAN range.
       # Alternatively, it could be explicitly set by the user in combination
       # with a starting VLAN ID.
-      network_num_networks        = 1
+      network_num_networks        = '<%= @host.deployment.nova.num_networks %>'
       network_fixed_range         = '<%= @host.deployment.nova.private_fixed_range %>'
       network_floating_range      = '<%= @host.deployment.nova.public_floating_range %>'
       network_private_iface       = '<%= @host.deployment.nova.compute_tenant_interface %>'

--- a/app/models/staypuft/concerns/host_open_stack_affiliation.rb
+++ b/app/models/staypuft/concerns/host_open_stack_affiliation.rb
@@ -43,3 +43,7 @@ module Staypuft
     end
   end
 end
+
+class ::Host::Managed::Jail < Safemode::Jail
+  allow :deployment
+end

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -148,6 +148,11 @@ module Staypuft
     validates :layout_name, presence: true, inclusion: { in: LayoutName::TYPES }
     validates :platform, presence: true, inclusion: { in: Platform::TYPES }
 
+    class Jail < Safemode::Jail
+      allow :amqp_provider, :networking, :layout_name, :platform, :nova_networking?, :neutron_networking?,
+        :nova, :neutron, :glance, :cinder, :passwords, :vips, :ips, :ha?
+    end
+
     # TODO(mtaylor)
     # Use conditional validations to validate the deployment multi-step form.
     # deployment.form_step should be used to check the form step the user is
@@ -187,6 +192,14 @@ module Staypuft
 
     def ha?
       self.layout_name == LayoutName::HA
+    end
+
+    def nova_networking?
+      networking == Networking::NOVA
+    end
+
+    def neutron_networking?
+      networking == Networking::NEUTRON
     end
 
     private

--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -34,6 +34,10 @@ module Staypuft
     # TODO: add EqualLogic UI parameters
 
 
+    class Jail < Safemode::Jail
+      allow :lvm_backend?, :nfs_backend?, :nfs_uri, :ceph_backend?, :equallogic_backend?
+    end
+
     def set_defaults
       self.driver_backend = DriverBackend::LVM
     end

--- a/app/models/staypuft/deployment/glance_service.rb
+++ b/app/models/staypuft/deployment/glance_service.rb
@@ -30,6 +30,10 @@ module Staypuft
               :if       => :nfs_backend?
     # TODO: network_path validation
 
+    class Jail < Safemode::Jail
+      allow :driver_backend, :pcmk_fs_device, :pcmk_fs_dir, :pcmk_fs_options
+    end
+
     def set_defaults
       self.driver_backend = DriverBackend::LOCAL
     end

--- a/app/models/staypuft/deployment/ips.rb
+++ b/app/models/staypuft/deployment/ips.rb
@@ -1,6 +1,10 @@
 module Staypuft
   class Deployment::IPS < Deployment::AbstractParamScope
 
+    class Jail < Safemode::Jail
+      allow :controller_ip, :controller_ips, :controller_fqdns
+    end
+
     def controllers
       @controllers ||= Hostgroup.
           includes(:deployment_role_hostgroup).

--- a/app/models/staypuft/deployment/neutron_service.rb
+++ b/app/models/staypuft/deployment/neutron_service.rb
@@ -88,6 +88,12 @@ module Staypuft
               :presence => true
     # TODO: interface name format validation
 
+    class Jail < Safemode::Jail
+      allow :networker_vlan_ranges, :compute_vlan_ranges, :network_segmentation, :enable_tunneling?,
+        :networker_tenant_interface, :networker_ovs_bridge_mappings, :networker_ovs_bridge_uplinks,
+        :compute_tenant_interface, :compute_ovs_bridge_mappings, :compute_ovs_bridge_uplinks
+    end
+
     def set_defaults
       self.network_segmentation   = NetworkSegmentation::VXLAN
       self.use_external_interface = 'false'

--- a/app/models/staypuft/deployment/nova_service.rb
+++ b/app/models/staypuft/deployment/nova_service.rb
@@ -80,7 +80,17 @@ module Staypuft
     def network_overrides
       { 'force_dhcp_release' => false }.tap do |h|
         h.update 'vlan_start' => self.vlan_range.split(':')[0] if self.vlan_manager?
-      end
+      end.to_yaml
+    end
+
+    # TODO: make this dynamic
+    def num_networks
+      1
+    end
+
+    class Jail < Safemode::Jail
+      allow :network_manager, :network_overrides, :private_fixed_range, :public_floating_range,
+        :compute_tenant_interface, :external_interface_name, :num_networks
     end
 
   end

--- a/app/models/staypuft/deployment/passwords.rb
+++ b/app/models/staypuft/deployment/passwords.rb
@@ -40,6 +40,11 @@ module Staypuft
               :if           => :single_mode?,
               :length       => { minimum: 6 }
 
+    class Jail < Safemode::Jail
+      allow :effective_value, :ceilometer_metering_secret, :heat_auth_encrypt_key,
+        :horizon_secret_key, :swift_shared_secret, :neutron_metadata_proxy_secret
+    end
+
     def set_defaults
       self.mode = Mode::RANDOM
       PASSWORD_LIST.each do |password_field|

--- a/app/models/staypuft/deployment/vips.rb
+++ b/app/models/staypuft/deployment/vips.rb
@@ -13,6 +13,10 @@ module Staypuft
 
     HUMAN = N_('Virtual IP addresses range')
 
+    class Jail < Safemode::Jail
+      allow :get
+    end
+
     def range
       (user_range || default_range)
       # TODO reserve the IP addresses


### PR DESCRIPTION
Whitelist methods referenced by dynamic params to prevent safe mode "Jail"
failures
