### PR TITLE
fixing cluster_control_ip value

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -472,7 +472,7 @@ module Staypuft
               'nova_public_vip'               => vip_format % :nova,
               'amqp_vip'                      => vip_format % :amqp,
               'swift_public_vip'              => vip_format % :swift,
-              'cluster_control_ip'            => '<%= @host.deployment.ips.controller_ip %>',
+              'cluster_control_ip'            => '<%= @host.deployment.ips.controller_ips.first %>',
               'lb_backend_server_addrs'       => '<%= @host.deployment.ips.controller_ips %>',
               'lb_backend_server_names'       => '<%= @host.deployment.ips.controller_fqdns %>' },
           'quickstack::pacemaker::common'          => {


### PR DESCRIPTION
deployment.ips.controller_ip fails (by design) when there are
multiple controllers. I needed deployment.ips.controller_ips.first
