### PR TITLE
For lvm cinder, use Ptable that includes cinder-volumes

### DIFF
--- a/app/controllers/staypuft/steps_controller.rb
+++ b/app/controllers/staypuft/steps_controller.rb
@@ -9,6 +9,10 @@ module Staypuft
       case step
       when :deployment_settings
         @layouts = ordered_layouts
+      when :services_overview
+        if !@deployment.ha? && @deployment.cinder.lvm_ptable.nil?
+          flash[:warning] = "Missing Partition Table 'LVM with cinder-volumes', LVM cinder backend won't work." 
+        end
       when :services_configuration
         @services_map = [:nova, :neutron, :glance, :cinder]
       end

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -228,6 +228,13 @@ module Staypuft
       end
     end
 
+    def controller_hostgroup
+      Hostgroup.includes(:deployment_role_hostgroup).
+        where(DeploymentRoleHostgroup.table_name => { deployment_id: self,
+                                                      role_id:       Staypuft::Role.controller }).
+        first
+    end
+
     private
 
     def update_layout

--- a/app/models/staypuft/deployment/ips.rb
+++ b/app/models/staypuft/deployment/ips.rb
@@ -6,12 +6,7 @@ module Staypuft
     end
 
     def controllers
-      @controllers ||= Hostgroup.
-          includes(:deployment_role_hostgroup).
-          where(DeploymentRoleHostgroup.table_name => { deployment_id: deployment,
-                                                        role_id:       Staypuft::Role.controller }).
-          first.
-          hosts.order(:id)
+      @controllers ||= deployment.controller_hostgroup.hosts.order(:id)
     end
 
     def controller_ips


### PR DESCRIPTION
If cinder backend is LVM, set the controller hostgroup's Ptable
to Ptable.find_by_name('LVM with cinder-volumes').

This ptable should possibly be referenced by a Setting object at some point
rather than relying on name matching.

At this point if the PTable isn't found, we just silently ignore it,
since this isn't yet in the installer and I don't want staypuft blowing up
over it. Once this is in the installer, we can consider the proper way
of handling this if the Ptable doesn't exist.

On initial testing this seems to work when switching back and forth
between LVM and NFS cinder storage in non-HA, and also on switching
between HA and non-HA where the cinder change comes along for the
ride.
