### PR TITLE
work around foreman safe mode whitelisting issue

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -164,7 +164,7 @@ module Staypuft
     def functional_dependencies
       amqp_provider               = { :string => '<%= @host.deployment.amqp_provider %>' }
       neutron                     = { :string => '<%= @host.deployment.neutron_networking? %>' }
-      ceilometer                  = { :string => '<%= !@host.deployment.ha? %>' }
+      ceilometer                  = { :string => '<%= @host.deployment.non_ha? %>' }
 
       # Nova
       network_manager             = { :string => '<%= @host.deployment.nova.network_manager %>' }

--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -179,7 +179,7 @@ module Staypuft
 
     class Jail < Safemode::Jail
       allow :amqp_provider, :networking, :layout_name, :platform, :nova_networking?, :neutron_networking?,
-        :nova, :neutron, :glance, :cinder, :passwords, :vips, :ips, :ha?
+        :nova, :neutron, :glance, :cinder, :passwords, :vips, :ips, :ha?, :non_ha?
     end
 
     # TODO(mtaylor)
@@ -221,6 +221,10 @@ module Staypuft
 
     def ha?
       self.layout_name == LayoutName::HA
+    end
+
+    def non_ha?
+      self.layout_name == LayoutName::NON_HA
     end
 
     def nova_networking?


### PR DESCRIPTION
For foreman safe mode, !false fails whitelisted evaluation.
For now I added a separate method for determining non_ha
