### PR TITLE
add validation for vlan range inputs

### DIFF
--- a/app/models/staypuft/deployment/neutron_service.rb
+++ b/app/models/staypuft/deployment/neutron_service.rb
@@ -32,10 +32,14 @@ module Staypuft
       HUMAN_AFTER = VLAN_HELP
     end
 
+    class NeutronVlanRangesValidator < ActiveModel::EachValidator
+      include Staypuft::Deployment::VlanRangeValuesValidator 
+    end
+
     validates :tenant_vlan_ranges,
-              :presence => true,
-              :if       => :vlan_segmentation?
-    # TODO: vlan range format validation
+              :presence            => true,
+              :if                  => :vlan_segmentation?,
+              :neutron_vlan_ranges => true
 
     module NetworkerTenantInterface
       HUMAN       = N_('Which interface to use for tenant networks:')

--- a/app/models/staypuft/deployment/nova_service.rb
+++ b/app/models/staypuft/deployment/nova_service.rb
@@ -64,11 +64,14 @@ module Staypuft
       HUMAN_AFTER = VLAN_HELP
     end
 
+    class NovaVlanRangeValidator < ActiveModel::EachValidator
+      include Staypuft::Deployment::VlanRangeValuesValidator
+    end
+
     validates :vlan_range,
-              :presence => true,
-              :if       => :vlan_manager?
-    # TODO: vlan range format validation
-    # TODO: determine whether this is a true range or a single value
+              :presence        => true,
+              :if              => :vlan_manager?,
+              :nova_vlan_range => true
 
     module ExternalInterfaceName
       HUMAN       = N_('Which interface to use for external networks:')

--- a/app/models/staypuft/deployment/vlan_range_values_validator.rb
+++ b/app/models/staypuft/deployment/vlan_range_values_validator.rb
@@ -1,0 +1,33 @@
+module Staypuft
+  module Deployment::VlanRangeValuesValidator
+    GENERAL_MSG = N_("Start and end vlan IDs required, in format '10:100'")
+    INT_VAL_MSG = N_("is not a valid integer between 1 and 4094")
+    FIRST_VALID = 1
+    LAST_VALID = 4024
+
+    def validate_each(record, attribute, value)
+
+      return if value.empty?
+
+      if value !~ /\A\d+:\d+\Z/
+        record.errors.add attribute, GENERAL_MSG
+        return
+      end
+
+      range_values = value.split(':').map(&:to_i)
+
+      range_values.all? do |value|
+        if value.between?(FIRST_VALID, LAST_VALID)
+          true
+        else
+          record.errors.add attribute, "Range boundary #{value} #{INT_VAL_MSG}"
+          false
+        end
+      end or return
+
+      unless range_values[1] >= range_values[0]
+        record.errors.add attribute, _("End VLAN ID must be equal to or greater than start VLAN ID.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Vlan range inputs should be in the format of begin:end
where begin and end are integers between 1 and 4024,
and end is greater than or equal to begin
