### PR TITLE
Fix error messages for host assignment

### DIFF
--- a/app/controllers/staypuft/deployments_controller.rb
+++ b/app/controllers/staypuft/deployments_controller.rb
@@ -94,12 +94,16 @@ module Staypuft
       end
 
       unless unassigned_hosts.empty?
-        flash[:warning] = 'Unassigned hosts: ' + unassigned_hosts.map(&:name_was).join(', ')
-        Rails.logger.warn(
-            "Unassigned hosts: \n" +
-                unassigned_hosts.
+        unassigned_messages = 'Unassigned hosts: <ul>' + unassigned_hosts.
+                    map { |h| format '<li>%s <ul>%s</ul></li>', h.name_was, h.errors.full_messages.map {|msg|
+                                     "<li>#{msg}</li>"}.join}.
+                    join + '</ul>'
+
+        flash[:error] = unassigned_messages
+        Rails.logger.warn('Unassigned hosts:\n' + unassigned_hosts.
                     map { |h| format '%s (%s)', h.name_was, h.errors.full_messages.join(',') }.
-                    join("\n"))
+                    join("\n") 
+)
       end
 
       redirect_to deployment_path(deployment)


### PR DESCRIPTION
This does 2 things for the host assignment error message reporting:
1) changes flash :warning to flash :error:
     This is a real error condition, so users should be properly
     alerted
2) Display the actual error messages to the user rather than burying
   them in logs:
     There are a variety of different conditions that can lead to
     host assignment failing, from UI-fixable stuff around setting
     operating system, etc. params in foreman to lower-level problems
     with DNS, DHCP, etc.

One remaining issue -- this isn't formatted in the best possible way.
If there are multiple error messages, the list gets a bit ugly,
but it's better than not providing any messages at all. If there's
an obvious way to better format this for the flash[:error] array, then
let me know -- otherwise perhaps this is good enough for now, as it's
a definite improvement over what we had previously.
