### PR TITLE
Do not fail on errors in autosign

### DIFF
--- a/app/lib/actions/staypuft/host/wait_until_host_ready.rb
+++ b/app/lib/actions/staypuft/host/wait_until_host_ready.rb
@@ -59,7 +59,8 @@ module Actions
 
         def host_ready?(host_id)
           host = ::Host.find(host_id)
-          host.reports.order('reported_at DESC').any? do |report|
+          # take reports oldest first ignoring always the first one (auto-sign)
+          host.reports.order('reported_at DESC')[0..-2].any? do |report|
             check_for_failures(report, host.id)
             report_change?(report)
           end


### PR DESCRIPTION
There may be errors in autosign report, staypuft deployment
orchestration should just ignore them and wait for results of
full puppet run after machine restarts.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1123463
