### PR TITLE
field-level validation for equallogic fields

### DIFF
--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -24,9 +24,13 @@ module Staypuft
           end
         rescue
           # not IP addr
-          # FIXME: future validation to allow hostnames too, not just IP addr
-          record.errors.add attribute, "Invalid Network Range Format"
-          false
+          # validating as fqdn
+          if /(?=^.{1,254}$)(^(((?!-)[a-zA-Z0-9-]{1,63}(?<!-))|((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63})$)/ =~ value
+            true
+          else
+            record.errors.add attribute, "Invalid IP address or FQDN supplied"
+            false
+          end
         end
       end
     end


### PR DESCRIPTION
A couple notes:
1) the actual validation requirements are included in comments near the
   'validates' entries. These were provided to me as the definitive
   rules -- so review here would be to make sure that the regexps, etc.
   validate as stated in the comments -- if there is some question around
   the validity of the comment itself, we should handle that separately
2) for the SAN IP address, the provided validation enforces it to be
   an actual IP address. Apparently, a hostname/fqdn is valid here too,
   so this validation needs to be expanded to handle that case. For the moment
   I'm not sure if it's better to leave this validation off until it's complete
   (if hostname-valued params will be common here), or if restricting it to an
   IP addr is fine for now (which would be the case if this is the common case
   and using a hostname/fqdn is more of an edge case.
