### PR TITLE
hack to get deployment.ips.controller_ips to work w/ multi-nics

### DIFF
--- a/app/models/staypuft/deployment/ips.rb
+++ b/app/models/staypuft/deployment/ips.rb
@@ -1,3 +1,5 @@
+require 'resolv'
+
 module Staypuft
   class Deployment::IPS < Deployment::AbstractParamScope
 
@@ -10,7 +12,9 @@ module Staypuft
     end
 
     def controller_ips
-      controllers.map &:ip
+      controllers.map do |controller|
+        ip_for_controller(controller)
+      end
     end
 
     def controller_fqdns
@@ -18,8 +22,15 @@ module Staypuft
     end
 
     def controller_ip
-      controllers.tap { |v| v.size == 1 or raise }.first.ip
+      ip_for_controller(controllers.tap { |v| v.size == 1 or raise }.first)
     end
 
+    # TODO: a better fix is needed once we have explicit subnet support in staypuft
+    # This is needed because host.ip doesn't always return the expected ip address
+    # when the host has more than one network interface -- this ensures that the
+    # provisioning network interface is the chosen one.
+    def ip_for_controller(controller)
+      Resolv::DNS.new(:nameserver => 'localhost').getaddress(controller.fqdn).to_s
+    end
   end
 end


### PR DESCRIPTION
host.ip doesn't return a predictable value when there is more than
one network interface. Once we explicitly support multiple subnets
in staypuft w/ the phase 3 development, we'll need something
less hackish than this -- "give me the IP for this host on $subnet"
It could be that we already have a reliable way to do this without
this DNS hack, in which case we should do that instead.

In any case, this seems to do the right thing for current multi-nic
deployments
