### PR TITLE
BZ 1127297: remove hosts from hostgroup when deleting hostgroups

### DIFF
--- a/app/models/staypuft/deployment.rb
+++ b/app/models/staypuft/deployment.rb
@@ -22,7 +22,6 @@ module Staypuft
     belongs_to :layout
 
     # needs to be defined before hostgroup association
-    before_destroy :prepare_destroy
     belongs_to :hostgroup, :dependent => :destroy
 
     has_many :deployment_role_hostgroups, :dependent => :destroy
@@ -316,11 +315,6 @@ module Staypuft
     # the form_step field to complete.
     def check_form_complete
       self.form_step = Deployment::STEP_COMPLETE if self.form_step.to_sym == Deployment::STEP_CONFIGURATION
-    end
-
-    def prepare_destroy
-      hosts.each &:open_stack_unassign
-      child_hostgroups.each &:destroy
     end
 
   end

--- a/app/models/staypuft/deployment_role_hostgroup.rb
+++ b/app/models/staypuft/deployment_role_hostgroup.rb
@@ -12,8 +12,15 @@ module Staypuft
     validates :role_id, :uniqueness => {:scope => :deployment_id}
     validates :hostgroup, :presence => true
     validates :hostgroup_id, :uniqueness => true
+    has_many :hosts, :through => :hostgroup
 
     validates  :deploy_order, :presence => true
+
+    before_destroy :prepare_destroy
+
+    def prepare_destroy
+      hosts.each &:open_stack_unassign
+    end
 
   end
 end


### PR DESCRIPTION
We were already doing this correctly on deployment delete, but
this commit moves it down one level, so any time we remove a
DeploymentRoleHostgroup, the hosts are removed too -- which
handles layout changes properly.
