### PR TITLE
BZ #1130574 - Use effective value for admin password display

### DIFF
--- a/app/views/staypuft/deployments/_deployment_summary.html.erb
+++ b/app/views/staypuft/deployments/_deployment_summary.html.erb
@@ -27,7 +27,7 @@
             <label class="col-sm-4 control-label text-muted"><%= _("Password") %></label>
             <div class="col-sm-8">
               <p class="form-control-static">
-                <span class="shown_password hide"><%= @deployment.passwords.admin %></span>
+                <span class="shown_password hide"><%= @deployment.passwords.effective_value(:admin) %></span>
                 <span class="hidden_password">********</span>
                 <a href="" id="hidden_password_toggle">
                   <span class="glyphicon glyphicon-eye-open"></span>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1130574

The admin password does not display the correct value when a single
password is set for the entire deployment. This corrects it to show the
effective value, depending on single_mode setting.
