### PR TITLE
Raise with some description

### DIFF
--- a/app/lib/staypuft/network_query.rb
+++ b/app/lib/staypuft/network_query.rb
@@ -58,7 +58,7 @@ module Staypuft
     end
 
     def controller_ip(subnet_type_name)
-      ip_for_host(controllers.tap { |v| v.size == 1 or raise }.first, subnet_type_name)
+      ip_for_host(controllers.tap { |v| v.size == 1 or raise('only one controller is allowed') }.first, subnet_type_name)
     end
 
     def controller_fqdns


### PR DESCRIPTION
While this is still not ideal and we should not allow the association to happen in the first place, we at least indicate what sort of exception occurred.
