### PR TITLE
BZ# 1139792 - Fix cinder checkbox validation

### DIFF
--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -148,14 +148,14 @@ module Staypuft
       if self.deployment.ha?
         params.delete :backend_lvm
       end
-      unless params.detect(lambda { false }) { |field| field }
-        errors[:base] << _("At least one storage backend must be selected")
+      unless params.detect(lambda { false }) { |field| self.send(field) == "true" }
+        errors.add :base, _("At least one storage backend must be selected")
       end
     end
 
     def equallogic_backends
       unless self.eqlxs.all? { |item| item.valid? }
-        errors[:base] << _("Please fix the problems in selected backends")
+        errors.add :base, _("Please fix the problems in selected backends")
       end
     end
   end

--- a/app/views/staypuft/steps/_cinder.html.erb
+++ b/app/views/staypuft/steps/_cinder.html.erb
@@ -2,7 +2,8 @@
   <h5><%= _(Staypuft::Deployment::CinderService::DriverBackend::HUMAN) %></h5>
   <div class="col-md-12 clearfix cinderPicker" id="cinderPicker">
     <%= f.fields_for :cinder, @deployment.cinder do |p| %>
-
+      <%= base_errors_for @deployment.cinder %>
+      <div class="form-group <%= @deployment.cinder.errors.empty? ? "" : 'has-error' %> hide"></div>
       <%= check_box_f_non_inline(p, :backend_nfs,
                                  :checked_value   => 'true',
                                  :unchecked_value => 'false',


### PR DESCRIPTION
When starting a new deployment, the cinder checkbox validation was not
operating correctly. This now display a proper error message and hilites
the tab.
