### PR TITLE
Remove LVM from cinder backend choices when deployment is HA

### DIFF
--- a/app/helpers/staypuft/application_helper.rb
+++ b/app/helpers/staypuft/application_helper.rb
@@ -30,7 +30,8 @@ module Staypuft
       text            = options.delete(:text)
       checked_value   = options.delete(:checked_value)
       unchecked_value = options.delete(:unchecked_value)
-      content_tag(:div, :class => 'checkbox') do
+      group_class     = options.delete(:group_class)
+      content_tag(:div, :class => "checkbox #{group_class}") do
         label_tag('') do
           f.check_box(attr, options, checked_value, unchecked_value) + " #{text} "
         end

--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -145,9 +145,7 @@ module Staypuft
 
     def at_least_one_backend_selected
       params = BACKEND_TYPE_PARAMS.clone
-      if self.deployment.ha?
-        params.delete :backend_lvm
-      end
+      params.delete :backend_lvm if self.deployment.ha?
       unless params.detect(lambda { false }) { |field| self.send(field) == "true" }
         errors.add :base, _("At least one storage backend must be selected")
       end

--- a/app/views/staypuft/steps/_cinder.html.erb
+++ b/app/views/staypuft/steps/_cinder.html.erb
@@ -7,7 +7,7 @@
       <%= check_box_f_non_inline(p, :backend_nfs,
                                  :checked_value   => 'true',
                                  :unchecked_value => 'false',
-                                 :text            => "NFS")
+                                 :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['nfs']))
       %>
       <div class="cinder_nfs_uri col-md-offset-1 hide">
 
@@ -20,19 +20,21 @@
       <%= check_box_f_non_inline(p, :backend_lvm,
                                  :checked_value   => 'true',
                                  :unchecked_value => 'false',
-                                 :text            => "LVM")
+                                 :checked         => @deployment.cinder.lvm_backend?,
+                                 :group_class     => @deployment.ha? ? "hide" : "",
+                                 :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['lvm']))
       %>
 
       <%= check_box_f_non_inline(p, :backend_ceph,
                                  :checked_value   => 'true',
                                  :unchecked_value => 'false',
-                                 :text            => "Ceph")
+                                 :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['ceph']))
       %>
 
       <%= check_box_f_non_inline(p, :backend_eqlx,
                                  :checked_value   => 'true',
                                  :unchecked_value => 'false',
-                                 :text            => "EqualLogic")
+                                 :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['equallogic']))
       %>
       <div class="cinder_equallogic col-md-offset-1 hide">
         <div id="eqlxs" class="cinder_equallogic_picker">


### PR DESCRIPTION
This will remove the LVM choice from cinder backends if the deployment
is an HA deployment.
