### PR TITLE
BZ #1117462 - Make all needed equallogic backend fields into array

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -277,19 +277,19 @@ module Staypuft
       cinder_rbd_secret_uuid                  = { :string => '<%= @host.deployment.cinder.rbd_secret_uuid %>' }
 
       cinder_backend_eqlx           = { :string => '<%= @host.deployment.cinder.equallogic_backend? %>' }
-      cinder_backend_eqlx_name      = ['eqlx_backend']
+      cinder_backend_eqlx_name      = { :array => '<%= @host.deployment.cinder.compute_eqlx_backend_names %>'}
       # TODO: confirm these params and add them to model where user input is needed
       # below dynamic calls are commented out since the model does not yet have san/chap entries
       cinder_san_ip                 = { :array => '<%= @host.deployment.cinder.compute_eqlx_san_ips %>' }
       cinder_san_login              = { :array => '<%= @host.deployment.cinder.compute_eqlx_san_logins %>' }
       cinder_san_password           = { :array => '<%= @host.deployment.cinder.compute_eqlx_san_passwords %>' }
       cinder_eqlx_group_name        = { :array => '<%= @host.deployment.cinder.compute_eqlx_group_names %>' }
-      cinder_eqlx_pool              = { :array => '<%= @host.deployment.cinder.compute_eqlx_pools %>'}
+      cinder_eqlx_pool              = { :array => '<%= @host.deployment.cinder.compute_eqlx_pools %>' }
 
-      cinder_san_thin_provision     = ['false']
-      cinder_eqlx_use_chap          = ['false']
-      cinder_eqlx_chap_login        = ['']
-      cinder_eqlx_chap_password     = ['']
+      cinder_san_thin_provision     = { :array => '<%= @host.deployment.cinder.compute_eqlx_thin_provision %>' }
+      cinder_eqlx_use_chap          = { :array => '<%= @host.deployment.cinder.compute_eqlx_use_chap %>' }
+      cinder_eqlx_chap_login        = { :array => '<%= @host.deployment.cinder.compute_eqlx_chap_logins %>' }
+      cinder_eqlx_chap_password     = { :array => '<%= @host.deployment.cinder.compute_eqlx_chap_passwords %>' }
 
       # Keystone
       keystonerc = 'true'

--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -61,7 +61,9 @@ module Staypuft
       allow :lvm_backend?, :nfs_backend?, :ceph_backend?, :equallogic_backend?,
         :multiple_backends?, :rbd_secret_uuid, :nfs_uri, :eqlxs, :eqlxs_attributes=,
         :compute_eqlx_san_ips, :compute_eqlx_san_logins, :compute_eqlx_san_passwords,
-        :compute_eqlx_group_names, :compute_eqlx_pools
+        :compute_eqlx_group_names, :compute_eqlx_pools, :compute_eqlx_thin_provision,
+        :compute_eqlx_use_chap, :compute_eqlx_chap_logins, :compute_eqlx_chap_passwords,
+        :compute_eqlx_backend_names
     end
 
     def set_defaults
@@ -121,10 +123,20 @@ module Staypuft
       Ptable.find_by_name('LVM with cinder-volumes')
     end
 
-    %w{san_ip san_login san_password group_name pool}.each do |name|
+    %w{san_ip san_login san_password group_name pool chap_login chap_password}.each do |name|
       define_method "compute_eqlx_#{name}s" do
         self.eqlxs.collect { |e| e.send name }
       end
+    end
+
+    %w{thin_provision use_chap}.each do |name|
+      define_method "compute_eqlx_#{name}" do
+        self.eqlxs.collect { |e| e.send name }
+      end
+    end
+
+    def compute_eqlx_backend_names
+      self.eqlxs.collect.with_index { |e,i| "eqlx_backend#{i+1}" }
     end
 
     private

--- a/app/models/staypuft/deployment/cinder_service/equallogic.rb
+++ b/app/models/staypuft/deployment/cinder_service/equallogic.rb
@@ -5,12 +5,17 @@ module Staypuft
     include ActiveModel::Validations
     extend ActiveModel::Naming
 
-    attr_accessor :id, :san_ip, :san_login, :san_password, :pool, :group_name
+    attr_accessor :id, :san_ip, :san_login, :san_password, :pool, :group_name,
+                  :thin_provision, :use_chap, :chap_login, :chap_password
     attr_reader :errors
 
     def initialize(attrs = {})
       @errors = ActiveModel::Errors.new(self)
       self.attributes = attrs
+      self.thin_provision = false
+      self.use_chap = false
+      self.chap_login = ''
+      self.chap_password = ''
     end
 
     def self.human_attribute_name(attr, options = {})
@@ -22,7 +27,9 @@ module Staypuft
     end
 
     def attributes
-      { 'san_ip' => nil, 'san_login' => nil, 'san_password' => nil, 'pool' => nil, 'group_name' => nil }
+      { 'san_ip' => nil, 'san_login' => nil, 'san_password' => nil, 'pool' => nil,
+        'group_name' => nil, 'thin_provision' => nil, 'use_chap' => nil,
+        'chap_login' => nil, 'chap_password' => nil }
     end
 
     def attributes=(attrs)


### PR DESCRIPTION
The thin_provision, use chap, chap login, chap password, and
backend_name were not set as arrays. This makes them into arrays, and
will then pass the correct values to puppet manifest.
