### PR TITLE
Change target for inserting custom js deface rule

### DIFF
--- a/app/overrides/foreman_hosts_edit.rb
+++ b/app/overrides/foreman_hosts_edit.rb
@@ -7,7 +7,7 @@ end
 
 Deface::Override.new(:virtual_path => "hosts/_form",
                      :name => "include_custom_js_for_hosts_edit",
-                     :insert_after => "erb[loud]:contains('form_for')",
+                     :insert_after => "li > a[href='#network']",
                      :text => "<%= javascript 'staypuft/host_edit'%>"
                      )
 


### PR DESCRIPTION
The original one seems to cause issues in production environment.
