### PR TITLE
calculate nova network size

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -222,6 +222,7 @@ module Staypuft
       # multi_host handled inline, since it's two separate static values 'true' and 'True'
       network_overrides           = { :hash =>   '<%= @host.deployment.nova.network_overrides %>' }
       network_num_networks        = { :string => '<%= @host.deployment.nova.num_networks %>' }
+      network_network_size        = { :string => '<%= @host.deployment.nova.network_size %>' }
       network_fixed_range         = { :string => '<%= @host.deployment.nova.private_fixed_range %>' }
       network_floating_range      = { :string => '<%= @host.deployment.nova.public_floating_range %>' }
       network_private_iface       = { :string => "<%= @host.network_query.interface_for_host('#{Staypuft::SubnetType::TENANT}') %>" }
@@ -686,6 +687,7 @@ module Staypuft
               'network_manager'            => network_manager,
               'network_overrides'          => network_overrides,
               'network_num_networks'       => network_num_networks,
+              'network_network_size'       => network_network_size,
               'network_fixed_range'        => network_fixed_range,
               'network_floating_range'     => network_floating_range,
               'network_private_iface'      => network_private_iface,


### PR DESCRIPTION
This gets rid of the default '256' nova network size, which required larger
fixed tenant ranges when using vlans. Now, network size is calculated
from the fixed tenant range and the number of networks, to make sure that
the networks all fit within the same address space.

This also includes validation to make sure that the fixed range is
large enough to allow for a minimum network size of 4.
