### PR TITLE
Fixes bz#1142743 - unnecessary redirect

### DIFF
--- a/app/controllers/staypuft/interface_assignments_controller.rb
+++ b/app/controllers/staypuft/interface_assignments_controller.rb
@@ -18,7 +18,6 @@ module Staypuft
 
       if errors.present?
         flash[:error] = errors.map{ |k, v| "#{k}: #{v}" }.join('<br />')
-        redirect_to deployment_path(@deployment)
       end
     end
 


### PR DESCRIPTION
The GUI glitch occured when a redirect was included as part of an AJAX return
