### PR TITLE
BZ #1151603: Change interface filter to look at non-VIP interfaces

### DIFF
--- a/app/views/staypuft/interface_assignments/_nics_assignment.html.erb
+++ b/app/views/staypuft/interface_assignments/_nics_assignment.html.erb
@@ -5,7 +5,7 @@
       <div class="panel-body">
         <% @subnets.each do |subnet| %>
           <% next if is_pxe?(@deployment, subnet) # we skip PXE network which is always on primary interface %>
-          <% next if @host.interfaces.vip.where(:subnet_id => subnet.id).present? # we skip assigned subnets %>
+          <% next if @host.interfaces.non_vip.where(:subnet_id => subnet.id).present? # we skip assigned subnets %>
           <%= render 'staypuft/subnets/subnet_pull',
                      :subnet => subnet,
                      :deployment => @deployment,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1151603

The interface assignment screen was supposed to filter out already
assigned, non-vip subnets. It was changed to 'vip' in a refactor. What
then happened is that the subnet where the vips were assigned would get
filtered out, and could no longer be assigned to an interface.
