### PR TITLE
BZ #1154669: Allow host to be set to existing hostgroup

### DIFF
--- a/app/controllers/staypuft/concerns/hosts_api_extensions.rb
+++ b/app/controllers/staypuft/concerns/hosts_api_extensions.rb
@@ -2,16 +2,18 @@ module Staypuft::Concerns::HostsApiExtensions
   extend ActiveSupport::Concern
 
   included do
-    prepend_before_filter :check_openstack_hostgroup, only: [:create, :update]
+    before_filter :check_openstack_hostgroup, only: [:create, :update]
   end
 
   def check_openstack_hostgroup
     if params[:host] and params[:host][:hostgroup_id]
       hostgroup_id = params[:host][:hostgroup_id]
       hg = Hostgroup.find(hostgroup_id)
-      if hg.ancestors.include? Hostgroup.get_base_hostgroup
-        Rails.logger.error "Cannot set a deployment hostgroup directly."
-        render :json => {:error => {:message => _('Cannot set a deployment hostgroup directly.') } }, :status => :forbidden
+      unless @host.deployment and @host.hostgroup == hg
+        if hg.ancestors.include? Hostgroup.get_base_hostgroup
+          Rails.logger.error "Cannot set a deployment hostgroup directly."
+          render :json => {:error => _('Cannot set a deployment hostgroup directly.') }, :status => :forbidden
+        end
       end
     end
   end

--- a/app/controllers/staypuft/concerns/hosts_controller_extensions.rb
+++ b/app/controllers/staypuft/concerns/hosts_controller_extensions.rb
@@ -9,10 +9,13 @@ module Staypuft::Concerns::HostsControllerExtensions
   def check_openstack_hostgroup
     if params[:host] and params[:host][:hostgroup_id]
       hostgroup_id = params[:host][:hostgroup_id]
-      if openstack_hostgroup? hostgroup_id
-        Rails.logger.error "Cannot set a deployment hostgroup directly."
-        error _('Invalid host group selected! Cannot select OpenStack deployment host group.')
-        render :action => :edit and return
+      hostgroup = Hostgroup.find(hostgroup_id)
+      unless hostgroup.deployment and @host.hostgroup == hostgroup
+        if openstack_hostgroup? hostgroup_id
+          Rails.logger.error "Cannot set a deployment hostgroup directly."
+          error _('Invalid host group selected! Cannot select OpenStack deployment host group.')
+          render :action => :edit and return
+        end
       end
     end
   end

--- a/app/overrides/foreman_hosts_edit.rb
+++ b/app/overrides/foreman_hosts_edit.rb
@@ -28,7 +28,8 @@ Deface::Override.new(:virtual_path => "hosts/_form",
                      :replace => "#{erb_tag}:contains(':hostgroup_id')",
                      :original => '04903c858c6f96ed5c015cac5960e02708d8fea8'
                      ) do
-"       <%=  select_f f, :hostgroup_id, accessible_hostgroups.reject { |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ }, :id, :to_label,
+"       <% hostgroups = accessible_hostgroups.reject { |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ && hg.to_label != @host.hostgroup.to_label } %>
+        <%=  select_f f, :hostgroup_id, hostgroups, :id, :to_label,
           { :include_blank => true},
           { :onchange => 'hostgroup_changed(this);', :'data-host-id' => @host.id,
             :'data-url' => (@host.new_record? || @host.type_changed?) ? process_hostgroup_hosts_path : hostgroup_or_environment_selected_hosts_path,

--- a/app/overrides/select_multiple_systems_hostgroup.rb
+++ b/app/overrides/select_multiple_systems_hostgroup.rb
@@ -10,6 +10,7 @@ Deface::Override.new(:virtual_path => "hosts/select_multiple_hostgroup",
                      :replace => "#{erb_tag}:contains(':id')",
                      :original => '<%= selectable_f f, :id, [[_("Select host group"),"disabled"],[_("*Clear host group*"), "" ]] + Hostgroup.all.map{|h| [h.to_label, h.id]}.sort,{}, :onchange => "toggle_multiple_ok_button(this)" %>'
                      ) do
-"  <%= selectable_f f, :id, [[_(\"Select host group\"),\"disabled\"],[_(\"*Clear host group*\"), \"\" ]] + Hostgroup.all.reject{ |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ }.map{|h| [h.to_label, h.id]}.sort,{},
+"   <% hostgroups = accessible_hostgroups.reject { |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ } %>
+    <%= selectable_f f, :id, [[_(\"Select host group\"),\"disabled\"],[_(\"*Clear host group*\"), \"\" ]] + hostgroups.map{|h| [h.to_label, h.id]}.sort,{},
         :onchange => \"toggle_multiple_ok_button(this)\" %>"
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1154669

If the host is already associated to a deployment, this allows the host
to be edited directly in foreman, and to keep the hostgroup the same. It
will not allow any other deployment hostgroups.
