### PR TITLE
BZ #1151606: Do not destroy VIPs when assigning interfaces

### DIFF
--- a/app/models/staypuft/interface_assigner.rb
+++ b/app/models/staypuft/interface_assigner.rb
@@ -110,7 +110,7 @@ module Staypuft
     end
 
     def unassign_physicals
-      @host.interfaces.physical.where(:subnet_id => @subnet.id).each do |interface|
+      @host.interfaces.physical.non_vip.where(:subnet_id => @subnet.id).each do |interface|
         unassign_physical(interface)
       end
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1151606

When interfaces are being assigned to subnets, Staypuft was destroying
the VIPs. And they would not get re-created. This keeps them from being
destroyed when a subnet with VIPs is moved around.
