### PR TITLE
Clean up the display of NIC assignment

### DIFF
--- a/app/views/staypuft/interface_assignments/_nics_assignment_overview.html.erb
+++ b/app/views/staypuft/interface_assignments/_nics_assignment_overview.html.erb
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="col-md-12">
+    <h3 data-toggle="collapse" data-target="#hosts_to_configure"><%= @hosts.count %> <%= "#{n_('Host', 'Hosts', @hosts.count)} #{_('to be configured')}" %> <span class="small glyphicon glyphicon-chevron-down"></span></h3>
+    <div id="hosts_to_configure" class="collapse">
+      <table class="table table-striped table-condensed">
+        <thead>
+          <tr>
+            <th><%= sort :name, :as => _('Host Name') %></th>
+            <th><%= @host.primary_interface %></th>
+            <% @interfaces.each do |interface| %>
+              <th><%= interface.identifier %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <% @hosts.each do |host| %>
+            <tr>
+              <td class="ellipsis">
+               <%= host_label(host) %>
+              </td>
+              <td>
+                <%= host.mac %><br/>
+                <%= host.ip %>
+              </td>
+              <% if host.interfaces.present? %>
+                <% @interfaces.each do |iface| %>
+                  <% interface = host.interfaces.where(identifier: iface.identifier).first %>
+                  <td>
+                    <%= interface.mac %><br/>
+                    <%= interface.ip %>
+                  </td>
+                <% end %>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/staypuft/interface_assignments/index.html.erb
+++ b/app/views/staypuft/interface_assignments/index.html.erb
@@ -5,46 +5,12 @@
 
 <% title _("Configure Interfaces (%s hosts)") % @hosts.size %>
 
-<div class="row">
-  <div class="col-md-12">
-    <h3 data-toggle="collapse" data-target="#hosts_to_configure"><%= @hosts.count %> <%= "#{n_('Host', 'Hosts', @hosts.count)} #{_('to be configured')}" %> <span class="small glyphicon glyphicon-chevron-down"></span></h3>
-    <div id="hosts_to_configure" class="collapse">
-      <table class="table table-striped table-condensed">
-        <thead>
-          <tr>
-            <th><%= sort :name, :as => _('Host Name') %></th>
-            <th><%= @host.primary_interface %></th>
-            <% @interfaces.each do |interface| %>
-              <th><%= interface.identifier %></th>
-            <% end %>
-          </tr>
-        </thead>
-        <tbody>
-          <% @hosts.each do |host| %>
-            <tr>
-              <td class="ellipsis">
-               <%= host_label(host) %>
-              </td>
-              <td>
-                <%= host.mac %><br/>
-                <%= host.ip %>
-              </td>
-              <% if host.interfaces.present? %>
-                <td>
-                  <% host.interfaces.each do |interface| %>
-                    <%= interface.mac %><br/>
-                    <%= interface.ip %>
-                  <% end %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+<div id="nics_assignment_overview">
+  <%= render 'staypuft/interface_assignments/nics_assignment_overview',
+           :host => @host,
+           :hosts => @hosts,
+           :interfaces => @interfaces %>
 </div>
-
 <div id="nics_assignment">
   <%= render 'staypuft/interface_assignments/nics_assignment',
            :host => @host,


### PR DESCRIPTION
The assignment table did not display the correct data in the correct
columns. This makes the display correct. Also changes the display of the
VIPs to use the tag instead of the auto-created MAC.
