### PR TITLE
Fix edit override when no hostgroup is currently selected

### DIFF
--- a/app/overrides/foreman_hosts_edit.rb
+++ b/app/overrides/foreman_hosts_edit.rb
@@ -28,7 +28,7 @@ Deface::Override.new(:virtual_path => "hosts/_form",
                      :replace => "#{erb_tag}:contains(':hostgroup_id')",
                      :original => '04903c858c6f96ed5c015cac5960e02708d8fea8'
                      ) do
-"       <% hostgroups = accessible_hostgroups.reject { |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ && hg.to_label != @host.hostgroup.to_label } %>
+"       <% hostgroups = accessible_hostgroups.reject { |hg| hg.to_label =~ /\#{Setting[:base_hostgroup]}\\/.*/ && (@host.hostgroup ? hg.to_label != @host.hostgroup.to_label : true) } -%>
         <%=  select_f f, :hostgroup_id, hostgroups, :id, :to_label,
           { :include_blank => true},
           { :onchange => 'hostgroup_changed(this);', :'data-host-id' => @host.id,


### PR DESCRIPTION
When a host doesn't have a hostgroup already selected, the edit override
for the openstack hostgroups throws an error.
