### PR TITLE
Set cinder's multiple_backends param also in HA controller

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -700,6 +700,7 @@ module Staypuft
               'pcmk_fs_options' => pcmk_fs_options },
           'quickstack::pacemaker::cinder'          => {
               'volume'                           => volume,
+              'multiple_backends'                => cinder_multiple_backends,
               'backend_iscsi'                    => cinder_backend_iscsi,
               'backend_nfs'                      => cinder_backend_nfs,
               'backend_gluster'                  => cinder_backend_gluster,


### PR DESCRIPTION
For non-HA controller it already works as it should - when more than
one backend is checked in the wizard, multiple_backends parameter is
set to true. For HA controller this parameter override was missing and
this commit adds it.
