### PR TITLE
BZ #1155768: Hash params need textarea for proper load/store

### DIFF
--- a/app/views/staypuft/deployments/_advanced_configuration.html.erb
+++ b/app/views/staypuft/deployments/_advanced_configuration.html.erb
@@ -41,20 +41,12 @@
                   <%= label_tag param_hash[:param_key].key %>
                 </div>
                 <div class="col-md-8">
-                  <%= text_field_tag format("staypuft_deployment[hostgroup_params][%s][puppetclass_params][%s][%s]",
-                                            param_hash[:hostgroup].id,
-                                            param_hash[:puppetclass].id,
-                                            param_hash[:param_key].key),
-                                     value     = param_hash[:hostgroup].current_param_value_str(param_hash[:param_key]),
-                                     :class    => "form-control",
-                                     :size     => "45",
-                                     disabled: true %>
-                  <% if Staypuft::Concerns::LookupKeyExtensions.has_erb? value %>
-                    <span class="help-block">
-                      <%= _('evaluates to: ') %>
-                      <%= Staypuft::Concerns::LookupKeyExtensions.evaluate_value param_hash[:hostgroup], value %>
-                    </span>
-                  <% end %>
+                  <%= render "param_field", {:hostgroup => param_hash[:hostgroup],
+                                            :puppetclass => param_hash[:puppetclass],
+                                            :param_key => param_hash[:param_key],
+                                            :disabled => true,
+                                            :show_evaluation => true
+                                            } %>
                 </div>
               </div>
               <br/>

--- a/app/views/staypuft/deployments/_param_field.html.erb
+++ b/app/views/staypuft/deployments/_param_field.html.erb
@@ -1,0 +1,27 @@
+                  <% input_name = format("staypuft_deployment[hostgroup_params][%s][puppetclass_params][%s][%s]",
+                                            hostgroup.id,
+                                            puppetclass.id,
+                                            param_key.key)
+                     param_value = hostgroup.current_param_value_str(param_key)
+                  %>
+                  <% unless param_key.key_type.to_sym == :hash %>
+                  <%= text_field_tag input_name,
+                                     param_value,
+                                     { :class    => "form-control",
+                                       :size     => "45",
+                                       disabled: local_assigns[:disabled] } %>
+                  <% else %>
+                  <%= text_area_tag input_name,
+                                    param_value,
+                                    { :class    => "form-control",
+                                      :size     => "5",
+                                      disabled: local_assigns[:disabled] } %>
+                  <% end %>
+                  <% if local_assigns[:show_evaluation] %>
+                    <% if Staypuft::Concerns::LookupKeyExtensions.has_erb? param_value %>
+                      <span class="help-block">
+                        <%= _('evaluates to: ') %>
+                        <%= Staypuft::Concerns::LookupKeyExtensions.evaluate_value hostgroup, param_value %>
+                      </span>
+                    <% end %>
+                  <% end %>

--- a/app/views/staypuft/deployments/edit.html.erb
+++ b/app/views/staypuft/deployments/edit.html.erb
@@ -36,13 +36,11 @@
                     <%= label_tag param_hash[:param_key].key %>
                   </div>
                   <div class="col-md-5">
-                    <%= text_field_tag format("staypuft_deployment[hostgroup_params][%s][puppetclass_params][%s][%s]",
-                                              param_hash[:hostgroup].id,
-                                              param_hash[:puppetclass].id,
-                                              param_hash[:param_key].key),
-                                       param_hash[:hostgroup].current_param_value_str(param_hash[:param_key]),
-                                       :class => "form-control",
-                                       :size  => "45" %>
+                    <%= render "param_field", {:hostgroup => param_hash[:hostgroup],
+                                              :puppetclass => param_hash[:puppetclass],
+                                              :param_key => param_hash[:param_key],
+                                              :disabled => false
+                                              } %>
                   </div>
                 </div>
                 <br/>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1155768

When a hash parameter is encountered, it must use a textarea instead of
a textfield, otherwise the yaml will be malformed. This also pulls these
fields out into a partial.
