### PR TITLE
relax tenant subnet validation to allow it to be shared

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -216,7 +216,7 @@ module Staypuft
                                            :required                => true,
                                            :foreman_managed_ips     => false,
                                            :default_to_provisioning => false,
-                                           :dedicated_subnet        => true,
+                                           :dedicated_subnet        => false,
                                            :layouts                 => ALL_LAYOUTS},
                      :storage         => { :name                    => Staypuft::SubnetType::STORAGE,
                                            :required                => true,


### PR DESCRIPTION
This commit removes the "must be on a dedicated subnet" check for tenant
network. However, sharing is only supported for Neutron vxlan and gre.
For Neutron vlan and flat, or for Nova networking, the tenant network
type must still be separated from the rest.
