### PR TITLE
for discovery environment, ignore power management (bmc, etc)

### DIFF
--- a/app/lib/actions/staypuft/host/build.rb
+++ b/app/lib/actions/staypuft/host/build.rb
@@ -45,7 +45,8 @@ module Actions
             end
           end
 
-          if power_management
+          # ignore power management for discovery environment
+          if power_management && (host.environment != Environment.get_discovery)
             restart_with_power_management power_management
           else
             restart_with_foreman_proxy host


### PR DESCRIPTION
We hit an issue where configuring fencing on the host pre-deployment caused
deploy reboot to fail. As it turns out, simply having the bmc nic's
username and password field filled in causes foreman to want to control
the host via bmc. This may be fine post-deployment (although we
probably have lingering bmc proxy problems for that to really work),
but for initial deployment, this breaks and I don't know that we
want to boot fencing-enabled hosts differently than others, even
if it does work -- so with this, discovery env hosts are rebooted
via the discovery image proxy regardless of whether they're
configured for fencing post-deployment
