### PR TITLE
BZ #1158680: Reassign PXE subnet when bond created on primary

### DIFF
--- a/app/models/staypuft/concerns/host_interface_management.rb
+++ b/app/models/staypuft/concerns/host_interface_management.rb
@@ -52,11 +52,18 @@ module Staypuft
       def network_query
         @network_query || NetworkQuery.new(self.hostgroup.deployment, self)
       end
-        
+
+      def primary_interface_is_bonded?
+        self.bond_interfaces.any? do |bond|
+          bond.attached_devices_identifiers.any? do |interface_identifier|
+            self.has_primary_interface? ? self.primary_interface == interface_identifier : false
+          end
+        end
+      end
     end
   end
 end
 
 class ::Host::Managed::Jail < Safemode::Jail
-  allow :network_query
+  allow :network_query, :primary_interface_is_bonded?
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1158680

When the primary interface is involved in a bond, reassign the
Provisioning/PXE subnet to the bond to which the primary interface is
involved.
