### PR TITLE
don't use fqdn for controller names in lb_backend_server_names

### DIFF
--- a/app/lib/staypuft/network_query.rb
+++ b/app/lib/staypuft/network_query.rb
@@ -91,6 +91,12 @@ module Staypuft
       controllers.map &:shortname
     end
 
+    def controller_pcmk_shortnames
+      controllers.map do |controller|
+        "pcmk-"+controller.shortname
+      end
+    end
+
     def get_vip(vip_name)
       if VIP_NAMES[vip_name]
         interface = @deployment.vip_nics.where(:tag => vip_name).first
@@ -100,7 +106,7 @@ module Staypuft
 
     class Jail < Safemode::Jail
       allow :ip_for_host, :interface_for_host, :network_address_for_host,
-            :controller_ip, :controller_ips, :controller_fqdns, :get_vip,
+            :controller_ip, :controller_ips, :controller_fqdns, :get_vip, :controller_pcmk_shortnames,
             :subnet_for_host, :gateway_subnet, :gateway_interface, :gateway_interface_mac
     end
 

--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -661,7 +661,7 @@ module Staypuft
               'private_ip'                    => private_ip,
               'cluster_control_ip'            => { :string => "<%= @host.deployment.network_query.controller_ips('#{Staypuft::SubnetType::MANAGEMENT}').first %>" },
               'lb_backend_server_addrs'       => { :array => "<%= @host.deployment.network_query.controller_ips('#{Staypuft::SubnetType::MANAGEMENT}') %>" },
-              'lb_backend_server_names'       => { :array => '<%= @host.deployment.network_query.controller_fqdns %>' },
+              'lb_backend_server_names'       => { :array => '<%= @host.deployment.network_query.controller_pcmk_shortnames %>' },
               'agent_type'                    => neutron_agent_type,
               'n1kv_plugin_additional_params' => n1kv_plugin_additional_params },
           'quickstack::pacemaker::common'          => {


### PR DESCRIPTION
This is required to support recent quickstack changes.
