### PR TITLE
validation for NFS URI (bug #1170700)

### DIFF
--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -31,10 +31,15 @@ module Staypuft
       HUMAN       = N_('NFS URI:')
       HUMAN_AFTER = Deployment::GlanceService::NFS_HELP
     end
+
+    class NfsUriValueValidator < ActiveModel::EachValidator
+      include Staypuft::Deployment::NfsUriValidator
+    end
+
     validates :nfs_uri,
-              :presence => true,
-              :if       => :nfs_backend?
-    # TODO: uri validation
+              :presence      => true,
+              :if            => :nfs_backend?,
+              :nfs_uri_value => true
 
     module SanIp
       HUMAN       = N_('SAN IP Addr:')

--- a/app/models/staypuft/deployment/glance_service.rb
+++ b/app/models/staypuft/deployment/glance_service.rb
@@ -28,10 +28,14 @@ module Staypuft
       HUMAN_AFTER = NFS_HELP
     end
 
+    class NfsNetworkPathValueValidator < ActiveModel::EachValidator
+      include Staypuft::Deployment::NfsUriValidator
+    end
+
     validates :nfs_network_path,
-              :presence => true,
-              :if       => :nfs_backend?
-    # TODO: network_path validation
+              :presence               => true,
+              :if                     => :nfs_backend?,
+              :nfs_network_path_value => true
 
     class Jail < Safemode::Jail
       allow :driver_backend, :pcmk_fs_type, :pcmk_fs_device, :pcmk_fs_options, :backend,

--- a/app/models/staypuft/deployment/ip_address_validator.rb
+++ b/app/models/staypuft/deployment/ip_address_validator.rb
@@ -1,30 +1,10 @@
 module Staypuft
   module Deployment::IpAddressValidator
-    NOT_RANGE_MSG = N_("Specify single IP address, not range")
-    INVALID_IP_OR_FQDN_MSG = N_("Invalid IP address or FQDN supplied")
+    include Staypuft::Deployment::IpCheck
 
     def validate_each(record, attribute, value)
       return if value.empty?
-
-      begin
-        ip_addr = IPAddr.new(value)
-        ip_range = ip_addr.to_range
-        if ip_range.begin == ip_range.end
-          true
-        else
-          record.errors.add attribute, NOT_RANGE_MSG
-          false
-        end
-      rescue
-        # not IP addr
-        # validating as fqdn
-        if /(?=^.{1,254}$)(^(((?!-)[a-zA-Z0-9-]{1,63}(?<!-))|((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63})$)/ =~ value
-          true
-        else
-          record.errors.add attribute, INVALID_IP_OR_FQDN_MSG
-          false
-        end
-      end
+      check_ip_or_hostname(record, attribute, value)
     end
   end
 end

--- a/app/models/staypuft/deployment/ip_check.rb
+++ b/app/models/staypuft/deployment/ip_check.rb
@@ -1,0 +1,28 @@
+module Staypuft
+  module Deployment::IpCheck
+    NOT_RANGE_MSG = N_("Specify single IP address, not range")
+    INVALID_IP_OR_FQDN_MSG = N_("Invalid IP address or FQDN supplied")
+
+    def check_ip_or_hostname(record, attribute, value)
+      begin
+        ip_addr = IPAddr.new(value)
+        ip_range = ip_addr.to_range
+        if ip_range.begin == ip_range.end
+          true
+        else
+          record.errors.add attribute, NOT_RANGE_MSG
+          false
+        end
+      rescue
+        # not IP addr
+        # validating as fqdn
+        if /(?=^.{1,254}$)(^(((?!-)[a-zA-Z0-9-]{1,63}(?<!-))|((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63})$)/ =~ value
+          true
+        else
+          record.errors.add attribute, INVALID_IP_OR_FQDN_MSG
+          false
+        end
+      end
+    end
+  end
+end

--- a/app/models/staypuft/deployment/nfs_uri_validator.rb
+++ b/app/models/staypuft/deployment/nfs_uri_validator.rb
@@ -1,0 +1,17 @@
+module Staypuft
+  module Deployment::NfsUriValidator
+    include Staypuft::Deployment::IpCheck
+
+    INVALID_URI_MESSAGE = N_('Specify NFS URI as &lt;server&gt;:&lt;local path&gt;')
+    def validate_each(record, attribute, value)
+      return if value.empty?
+      match = /(.+):(.+)/.match(value)
+      if match
+        check_ip_or_hostname(record, attribute, match[1])
+      else
+        record.errors.add attribute, INVALID_URI_MESSAGE
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added NFS uri validation for cinder and glance.

https://bugzilla.redhat.com/show_bug.cgi?id=1170700

Validates format of <server IP or hostname/fqdn>:<local path>

The first element must be an IP address or valid hostname/fqdn.
For the local path element, the only validation is that it's
not empty.
