### PR TITLE
Enable NetApp driver for Cinder

### DIFF
--- a/app/assets/javascripts/staypuft/staypuft.js
+++ b/app/assets/javascripts/staypuft/staypuft.js
@@ -215,6 +215,61 @@ $('.neutron_ml2_mechanisms').parent().parent().removeClass('col-md-6').addClass(
     }
   }
 
+  showCinderNetApp();
+  // trigger function whenever NetApp checkmark is changed
+  $("#staypuft_deployment_cinder_backend_netapp").change(showCinderNetApp);
+
+  /**
+   * Shows NetApp configuration options if it is selected as a backend
+   */
+  function showCinderNetApp() {
+    if ($('#staypuft_deployment_cinder_backend_netapp').is(":checked")) {
+      $('.cinder_netapp').show();
+      if($('#netapps').children().length == 0) {
+        $('.add_another_netapp').click();
+      }
+    }
+    else {
+      $('.cinder_netapp').hide();
+    }
+  }
+
+  /**
+   * The user first selects their NetApp storage family and protocol
+   * and then relevant options are presented to them.
+   */
+  function showHideNetAppOptions(){
+    $('#netapps').children().each(function(){
+      var family = $(this).find('.netapp-main select[name*=storage_family]').val()
+      var protocol = $(this).find('.netapp-main select[name*=storage_protocol]').val()
+
+      // Hide all NetApp options
+      $(this).find('.netapp-option').hide();
+      $(this).find('.netapp-main select[name*=storage_protocol]').removeAttr("disabled");
+
+      // Selectively show options based on storage family & protocol
+      if (family == 'eseries'){
+        protocol = 'iscsi';
+        $(this).find('.netapp-main select[name*=storage_protocol]').val(protocol).attr('disabled', 'disabled');
+        $(this).find('.netapp-eseries').show();
+      }
+
+      if (protocol == 'nfs'){
+        $(this).find('.netapp-nfs').show();
+      }
+
+      if (protocol == 'iscsi' && family == 'ontap_7mode'){
+        $(this).find('.netapp-7mode-iscsi').show();
+      }
+
+      if (family == 'ontap_cluster'){
+        $(this).find('.netapp-vserver').show();
+      }
+
+    })
+
+  }
+
   showNeutronMl2CiscoNexus();
   $("#staypuft_deployment_neutron_ml2_cisco_nexus").change(showNeutronMl2CiscoNexus);
   function showNeutronMl2CiscoNexus() {
@@ -405,6 +460,25 @@ $('.neutron_ml2_mechanisms').parent().parent().removeClass('col-md-6').addClass(
       var previous_span_number = $('#eqlxs').children().eq(-2).find('h5').find('.server_number');
       added_form_span.html(parseInt(previous_span_number.html(), 10) + 1);
     }
+  })
+
+  /**
+   * Adds another NetApp storage system configuration section
+   */
+  $("button.add_another_netapp").live("click", function() {
+    var netapp_form = function () {
+      return $('#netapp_form_template').text().replace(/NEW_RECORD/g, new Date().getTime());
+    }
+    $('#netapps').append(netapp_form());
+    if($('#netapps').children().length > 1) {
+      var added_form_span = $('#netapps').children().last().find('h5').find('.server_number');
+      var previous_span_number = $('#netapps').children().eq(-2).find('h5').find('.server_number');
+      added_form_span.html(parseInt(previous_span_number.html(), 10) + 1);
+    }
+
+    // Unbind existing handlers & add event handlers to all NetApp config sections
+    $(".netapp-main select[name*=storage_family]").unbind().change(showHideNetAppOptions);
+    $(".netapp-main select[name*=storage_protocol]").unbind().change(showHideNetAppOptions);
   })
 
   $("button.add_another_switch").live("click", function() {

--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -305,6 +305,22 @@ module Staypuft
       cinder_eqlx_chap_login        = { :array => '<%= @host.deployment.cinder.compute_eqlx_chap_logins %>' }
       cinder_eqlx_chap_password     = { :array => '<%= @host.deployment.cinder.compute_eqlx_chap_passwords %>' }
 
+      cinder_backend_netapp           = { :string => '<%= @host.deployment.cinder.netapp_backend? %>' }
+      cinder_netapp_hostname          = { :array => '<%= @host.deployment.cinder.compute_netapp_hostnames %>' }
+      cinder_netapp_login             = { :array => '<%= @host.deployment.cinder.compute_netapp_logins %>' }
+      cinder_netapp_password          = { :array => '<%= @host.deployment.cinder.compute_netapp_passwords %>' }
+      cinder_netapp_server_port       = { :array => '<%= @host.deployment.cinder.compute_netapp_server_ports %>' }
+      cinder_netapp_storage_family    = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_families %>' }
+      cinder_netapp_transport_type    = { :array => '<%= @host.deployment.cinder.compute_netapp_transport_types %>' }
+      cinder_netapp_storage_protocol  = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_protocols %>' }
+      cinder_netapp_nfs_shares_config = { :array => '<%= @host.deployment.cinder.compute_netapp_nfs_shares_configs %>' }
+      cinder_netapp_volume_list       = { :array => '<%= @host.deployment.cinder.compute_netapp_volume_lists %>' }
+      cinder_netapp_vfiler            = { :array => '<%= @host.deployment.cinder.compute_netapp_vfilers %>' }
+      cinder_netapp_vserver           = { :array => '<%= @host.deployment.cinder.compute_netapp_vservers %>' }
+      cinder_netapp_controller_ips    = { :array => '<%= @host.deployment.cinder.compute_netapp_controller_ips %>' }
+      cinder_netapp_sa_password       = { :array => '<%= @host.deployment.cinder.compute_netapp_sa_passwords %>' }
+      cinder_netapp_storage_pools     = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_pools %>' }
+
       # Keystone
       keystonerc = 'true'
 
@@ -519,6 +535,7 @@ module Staypuft
               'rbd_user'                         => cinder_rbd_user,
               'rbd_secret_uuid'                  => cinder_rbd_secret_uuid,
               'backend_eqlx'                     => cinder_backend_eqlx,
+              'backend_netapp'                   => cinder_backend_netapp,
               'san_ip'                           => cinder_san_ip,
               'san_login'                        => cinder_san_login,
               'san_password'                     => cinder_san_password,
@@ -527,7 +544,21 @@ module Staypuft
               'eqlx_pool'                        => cinder_eqlx_pool,
               'eqlx_use_chap'                    => cinder_eqlx_use_chap,
               'eqlx_chap_login'                  => cinder_eqlx_chap_login,
-              'eqlx_chap_password'               => cinder_eqlx_chap_password },
+              'eqlx_chap_password'               => cinder_eqlx_chap_password,
+              'netapp_hostname'                  => cinder_netapp_hostname,
+              'netapp_login'                     => cinder_netapp_login,
+              'netapp_password'                  => cinder_netapp_password,
+              'netapp_server_port'               => cinder_netapp_server_port,
+              'netapp_storage_family'            => cinder_netapp_storage_family,
+              'netapp_transport_type'            => cinder_netapp_transport_type,
+              'netapp_storage_protocol'          => cinder_netapp_storage_protocol,
+              'netapp_nfs_shares_config'         => cinder_netapp_nfs_shares_config,
+              'netapp_volume_list'               => cinder_netapp_volume_list,
+              'netapp_vfiler'                    => cinder_netapp_vfiler,
+              'netapp_vserver'                   => cinder_netapp_vserver,
+              'netapp_controller_ips'            => cinder_netapp_controller_ips,
+              'netapp_sa_password'               => cinder_netapp_sa_password,
+              'netapp_storage_pools'             => cinder_netapp_storage_pools },
           'quickstack::pacemaker::keystone'        => {
               'keystonerc'     => keystonerc,
               'admin_password' => admin_pw,

--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -313,6 +313,7 @@ module Staypuft
       cinder_netapp_storage_family    = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_families %>' }
       cinder_netapp_transport_type    = { :array => '<%= @host.deployment.cinder.compute_netapp_transport_types %>' }
       cinder_netapp_storage_protocol  = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_protocols %>' }
+      cinder_netapp_nfs_shares        = { :array => '<%= @host.deployment.cinder.compute_netapp_nfs_shares %>' }
       cinder_netapp_nfs_shares_config = { :array => '<%= @host.deployment.cinder.compute_netapp_nfs_shares_configs %>' }
       cinder_netapp_volume_list       = { :array => '<%= @host.deployment.cinder.compute_netapp_volume_lists %>' }
       cinder_netapp_vfiler            = { :array => '<%= @host.deployment.cinder.compute_netapp_vfilers %>' }
@@ -552,6 +553,7 @@ module Staypuft
               'netapp_storage_family'            => cinder_netapp_storage_family,
               'netapp_transport_type'            => cinder_netapp_transport_type,
               'netapp_storage_protocol'          => cinder_netapp_storage_protocol,
+              'netapp_nfs_shares'                => cinder_netapp_nfs_shares,
               'netapp_nfs_shares_config'         => cinder_netapp_nfs_shares_config,
               'netapp_volume_list'               => cinder_netapp_volume_list,
               'netapp_vfiler'                    => cinder_netapp_vfiler,

--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -86,6 +86,9 @@ module Staypuft
     module NetappStorageProtocol
       HUMAN   = N_('Storage Protocol:')
     end
+    module NetappNfsShares
+      HUMAN   = N_('NFS Shares:')
+    end
     module NetappNfsSharesConfig
       HUMAN   = N_('NFS Shares Config:')
     end
@@ -123,7 +126,7 @@ module Staypuft
         :netapps, :compute_netapp_hostnames, :compute_netapp_logins, :compute_netapp_passwords,
         :compute_netapp_server_ports, :compute_netapp_storage_families,
         :compute_netapp_transport_types, :compute_netapp_storage_protocolss,
-        :compute_netapp_nfs_shares_configs, :compute_netapp_volume_list,
+        :compute_netapp_nfs_shares, :compute_netapp_nfs_shares_configs, :compute_netapp_volume_list,
         :compute_netapp_vfilers, :compute_netapp_vservers, :compute_netapp_controller_ips,
         :compute_netapp_sa_passwords, :compute_netapp_storage_pools
     end

--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -5,11 +5,12 @@ module Staypuft
       'cinder'
     end
 
-    BACKEND_TYPE_PARAMS = :backend_eqlx, :backend_nfs, :backend_lvm, :backend_ceph
+    BACKEND_TYPE_PARAMS = :backend_eqlx, :backend_nfs, :backend_lvm, :backend_ceph, :backend_netapp
     BACKEND_PARAMS = :nfs_uri, :rbd_secret_uuid
 
     param_attr *BACKEND_TYPE_PARAMS, *BACKEND_PARAMS
     param_attr_array :eqlxs => Equallogic
+    param_attr_array :netapps => Netapp
 
     after_save :set_lvm_ptable
 
@@ -18,10 +19,12 @@ module Staypuft
       NFS        = 'nfs'
       CEPH       = 'ceph'
       EQUALLOGIC = 'equallogic'
+      NETAPP     = 'netapp'
       LABELS     = { LVM        => N_('LVM'),
                      NFS        => N_('NFS'),
                      CEPH       => N_('Ceph'),
-                     EQUALLOGIC => N_('EqualLogic') }
+                     EQUALLOGIC => N_('EqualLogic'),
+                     NETAPP     => N_('NetApp') }
       TYPES      = LABELS.keys
       HUMAN      = N_('Choose Driver Backend')
     end
@@ -62,12 +65,67 @@ module Staypuft
     validate :equallogic_backends,
              :if          => :equallogic_backend?
 
+    module NetappHostname
+      HUMAN   = N_('Hostname:')
+    end
+    module NetappLogin
+      HUMAN   = N_('Login:')
+    end
+    module NetappPassword
+      HUMAN   = N_('Password:')
+    end
+    module NetappServerPort
+      HUMAN   = N_('Server Port:')
+    end
+    module NetappStorageFamily
+      HUMAN   = N_('Storage Family:')
+    end
+    module NetappTransportType
+      HUMAN   = N_('Transport Type:')
+    end
+    module NetappStorageProtocol
+      HUMAN   = N_('Storage Protocol:')
+    end
+    module NetappNfsSharesConfig
+      HUMAN   = N_('NFS Shares Config:')
+    end
+    module NetappVolumeList
+      HUMAN   = N_('Volume List:')
+    end
+    module NetappVfiler
+      HUMAN   = N_('vFiler:')
+    end
+    module NetappVserver
+      HUMAN   = N_('Storage Virtual Machine (SVM):')
+    end
+    module NetappControllerIps
+      HUMAN   = N_('Controller IPs:')
+    end
+    module NetappSaPassword
+      HUMAN   = N_('SA Password:')
+    end
+    module NetappStoragePools
+      HUMAN   = N_('Storage Pools:')
+    end
+
+    validates :netapps,
+              :presence   => true,
+              :if         => :netapp_backend?
+    validate :netapp_backends,
+             :if          => :netapp_backend?
+
     class Jail < Safemode::Jail
-      allow :lvm_backend?, :nfs_backend?, :ceph_backend?, :equallogic_backend?,
+      allow :lvm_backend?, :nfs_backend?, :ceph_backend?, :equallogic_backend?, :netapp_backend?,
         :multiple_backends?, :rbd_secret_uuid, :nfs_uri, :eqlxs, :eqlxs_attributes=,
         :compute_eqlx_san_ips, :compute_eqlx_san_logins, :compute_eqlx_san_passwords,
         :compute_eqlx_group_names, :compute_eqlx_pools, :compute_eqlx_thin_provision,
-        :compute_eqlx_use_chap, :compute_eqlx_chap_logins, :compute_eqlx_chap_passwords
+        :compute_eqlx_use_chap, :compute_eqlx_chap_logins, :compute_eqlx_chap_passwords,
+        :netapps, :compute_netapp_hostnames, :compute_netapp_logins, :compute_netapp_passwords,
+        :compute_netapp_server_ports, :compute_netapp_storage_families,
+        :compute_netapp_transport_types, :compute_netapp_storage_protocolss,
+        :compute_netapp_nfs_shares_configs, :compute_netapp_volume_list,
+        :compute_netapp_vfilers, :compute_netapp_vservers, :compute_netapp_controller_ips,
+        :compute_netapp_sa_passwords, :compute_netapp_storage_pools
     end
 
     def set_defaults
@@ -75,6 +133,7 @@ module Staypuft
       self.backend_ceph = "false"
       self.backend_nfs = "false"
       self.backend_eqlx = "false"
+      self.backend_netapp = "false"
       self.rbd_secret_uuid = SecureRandom.uuid
     end
 
@@ -99,8 +158,13 @@ module Staypuft
       self.backend_eqlx == "true"
     end
 
+    def netapp_backend?
+      self.backend_netapp == "true"
+    end
+
     def multiple_backends?
       (equallogic_backend? and self.eqlxs.length > 1) or
+        (netapp_backend? and self.netapps.length > 1) or
         BACKEND_TYPE_PARAMS.select { |type| send(type.to_s) == "true" }.length > 1
     end
 
@@ -115,7 +179,8 @@ module Staypuft
       { "backend_lvm" => backend_lvm, "backend_ceph" => backend_ceph,
         "backend_nfs" => backend_nfs, "backend_eqlx" => backend_eqlx,
         "nfs_uri" => nfs_uri, "rbd_secret_uuid" => rbd_secret_uuid,
-        "eqlxs" => self.eqlxs }
+        "eqlxs" => self.eqlxs, "backend_netapp" => backend_netapp,
+        "netapps" => self.netapps }
     end
 
     def lvm_ptable
@@ -159,6 +224,12 @@ module Staypuft
 
     def equallogic_backends
       unless self.eqlxs.all? { |item| item.valid? }
+        errors.add :base, _("Please fix the problems in selected backends")
+      end
+    end
+
+    def netapp_backends
+      unless self.netapps.all? { |item| item.valid? }
         errors.add :base, _("Please fix the problems in selected backends")
       end
     end

--- a/app/models/staypuft/deployment/cinder_service/netapp.rb
+++ b/app/models/staypuft/deployment/cinder_service/netapp.rb
@@ -7,8 +7,8 @@ module Staypuft
 
     attr_accessor :id, :hostname, :login, :password, :server_port,
                   :storage_family, :transport_type, :storage_protocol,
-                  :nfs_shares_config, :volume_list, :vfiler, :vserver,
-                  :controller_ips, :sa_password, :storage_pools
+                  :nfs_shares, :nfs_shares_config, :volume_list, :vfiler,
+                  :vserver, :controller_ips, :sa_password, :storage_pools
     attr_reader :errors
 
     STORAGE_FAMILIES = { :ontap_cluster => 'Clustered Data ONTAP',
@@ -37,7 +37,7 @@ module Staypuft
     def attributes
       { 'hostname' => nil, 'login' => nil, 'password' => nil,
         'server_port' => nil, 'storage_family' => nil, 'transport_type' => nil,
-        'storage_protocol' => nil, 'nfs_shares_config' => nil,
+        'storage_protocol' => nil, 'nfs_shares' => nil, 'nfs_shares_config' => nil,
         'volume_list' => nil, 'vfiler' => nil, 'vserver' => nil,
         'controller_ips' => nil, 'sa_password' => nil,
         'storage_pools' => nil }

--- a/app/models/staypuft/deployment/cinder_service/netapp.rb
+++ b/app/models/staypuft/deployment/cinder_service/netapp.rb
@@ -1,0 +1,59 @@
+#encoding: utf-8
+module Staypuft
+  class Deployment::CinderService::Netapp
+    include ActiveModel::Serializers::JSON
+    include ActiveModel::Validations
+    extend ActiveModel::Naming
+
+    attr_accessor :id, :hostname, :login, :password, :server_port,
+                  :storage_family, :transport_type, :storage_protocol,
+                  :nfs_shares_config, :volume_list, :vfiler, :vserver,
+                  :controller_ips, :sa_password, :storage_pools
+    attr_reader :errors
+
+    STORAGE_FAMILIES = { :ontap_cluster => 'Clustered Data ONTAP',
+                         :ontap_7mode => 'Data ONTAP 7-mode',
+                         :eseries => 'E-Series' }
+    STORAGE_PROTOCOLS = { :nfs => 'NFS', :iscsi => 'iSCSI' }
+    TRANSPORT_TYPES = { :http => 'http', :https => 'https' }
+
+    def initialize(attrs = {})
+      @errors = ActiveModel::Errors.new(self)
+      self.attributes = attrs
+      self.server_port = 80
+      self.storage_family = 'ontap_cluster'
+      self.transport_type = 'http'
+      self.storage_protocol = 'nfs'
+    end
+
+    def self.human_attribute_name(attr, options = {})
+      attr
+    end
+
+    def self.lookup_ancestors
+      [self]
+    end
+
+    def attributes
+      { 'hostname' => nil, 'login' => nil, 'password' => nil,
+        'server_port' => nil, 'storage_family' => nil, 'transport_type' => nil,
+        'storage_protocol' => nil, 'nfs_shares_config' => nil,
+        'volume_list' => nil, 'vfiler' => nil, 'vserver' => nil,
+        'controller_ips' => nil, 'sa_password' => nil,
+        'storage_pools' => nil }
+    end
+
+    def attributes=(attrs)
+      attrs.each { |attr, value| send "#{attr}=", value } unless attrs.nil?
+    end
+
+    validates :login,
+              presence: true,
+              format: /\A[a-zA-Z\d][\w\.\-]*[\w\-]\z/,
+              length: { maximum: 16 }
+    validates :password,
+              presence: true,
+              format: /\A[!-~]+\z/,
+              length: { minimum:3, maximum: 16 }
+  end
+end

--- a/app/views/staypuft/steps/_cinder.html.erb
+++ b/app/views/staypuft/steps/_cinder.html.erb
@@ -35,6 +35,13 @@
                                  :unchecked_value => 'false',
                                  :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['equallogic']))
       %>
+
+      <%= check_box_f_non_inline(p, :backend_netapp,
+                                 :checked_value   => 'true',
+                                 :unchecked_value => 'false',
+                                 :text            => _(Staypuft::Deployment::CinderService::DriverBackend::LABELS['netapp']))
+      %>
+
       <div class="cinder_equallogic col-md-offset-1 hide">
         <div id="eqlxs" class="cinder_equallogic_picker">
         <% @deployment.cinder.eqlxs.each_with_index do |eqlx, index| %>
@@ -48,6 +55,20 @@
         </script>
         <button type="button" class= "btn btn-primary btn-sm add_another_server"><%= _("Add Another Server") %></button>
     </div>
+
+      <div class="cinder_netapp col-md-offset-1 hide">
+        <div id="netapps" class="cinder_netapp_picker">
+        <% @deployment.cinder.netapps.each_with_index do |netapp, index| %>
+          <%= p.fields_for "netapps[]", netapp, index: index do |e| %>
+            <% render partial: 'cinder_netapp_form', locals: {e: e} %>
+          <% end %>
+        <% end %>
+        </div>
+        <script type='html/template' id='netapp_form_template'>
+          <%= p.fields_for 'netapps[]', Staypuft::Deployment::CinderService::Netapp.new, index: 'NEW_RECORD' do |e| render(partial: 'cinder_netapp_form', locals: {e: e}); end %>
+        </script>
+        <button type="button" class= "btn btn-primary btn-sm add_another_netapp"><%= _("Add Another NetApp Storage System") %></button>
+      </div>
     <%end%>
   </div>
 </div>

--- a/app/views/staypuft/steps/_cinder_netapp_form.html.erb
+++ b/app/views/staypuft/steps/_cinder_netapp_form.html.erb
@@ -30,7 +30,7 @@
                          label:      _(Staypuft::Deployment::CinderService::NetappNfsSharesConfig::HUMAN) %>
             </div>
 
-            <div class="netapp-7mode-iscsi netapp-option hidden">
+            <div class="netapp-7mode-iscsi netapp-option hide">
               <%= text_f e, :volume_list, class: "cinder_netapp",
                          label:      _(Staypuft::Deployment::CinderService::NetappVolumeList::HUMAN) %>
               <%= text_f e, :vfiler, class: "cinder_netapp",
@@ -42,7 +42,7 @@
                          label:      _(Staypuft::Deployment::CinderService::NetappVserver::HUMAN) %>
             </div>
 
-            <div class="netapp-eseries netapp-option hidden">
+            <div class="netapp-eseries netapp-option hide">
               <%= text_f e, :controller_ips, class: "cinder_netapp",
                          label:      _(Staypuft::Deployment::CinderService::NetappControllerIps::HUMAN) %>
               <%= text_f e, :sa_password, class: "cinder_netapp",

--- a/app/views/staypuft/steps/_cinder_netapp_form.html.erb
+++ b/app/views/staypuft/steps/_cinder_netapp_form.html.erb
@@ -26,6 +26,8 @@
             </div>
 
             <div class="netapp-nfs netapp-option">
+              <%= text_f e, :nfs_shares, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappNfsShares::HUMAN) %>
               <%= text_f e, :nfs_shares_config, class: "cinder_netapp",
                          label:      _(Staypuft::Deployment::CinderService::NetappNfsSharesConfig::HUMAN) %>
             </div>

--- a/app/views/staypuft/steps/_cinder_netapp_form.html.erb
+++ b/app/views/staypuft/steps/_cinder_netapp_form.html.erb
@@ -1,0 +1,53 @@
+          <div class="netapp well">
+            <h5 class="muted"><a href="#" class="remove"><i class="glyphicon glyphicon-remove-sign ">&nbsp;</i></a>&nbsp;Storage System #<span class="server_number">1</span></h5>
+            
+            <div class="netapp-main">
+              <%= select_f e, :storage_family, Staypuft::Deployment::CinderService::Netapp::STORAGE_FAMILIES,
+                         :first, :last, 
+                         {},
+                         { :label => _(Staypuft::Deployment::CinderService::NetappStorageFamily::HUMAN) } %>
+              <%= select_f e, :storage_protocol, Staypuft::Deployment::CinderService::Netapp::STORAGE_PROTOCOLS,
+                         :first, :last, 
+                         {},
+                         { :label => _(Staypuft::Deployment::CinderService::NetappStorageProtocol::HUMAN) } %>
+              <%= text_f e, :hostname, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappHostname::HUMAN) %>
+              <%= text_f e, :login, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappLogin::HUMAN) %>
+              <%= password_f e, :password, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappPassword::HUMAN) %>
+              <%= text_f e, :server_port, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappServerPort::HUMAN) %>
+              
+              <%= select_f e, :transport_type, Staypuft::Deployment::CinderService::Netapp::TRANSPORT_TYPES,
+                         :first, :last,
+                         {},
+                         { :label => _(Staypuft::Deployment::CinderService::NetappTransportType::HUMAN) } %>
+            </div>
+
+            <div class="netapp-nfs netapp-option">
+              <%= text_f e, :nfs_shares_config, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappNfsSharesConfig::HUMAN) %>
+            </div>
+
+            <div class="netapp-7mode-iscsi netapp-option hidden">
+              <%= text_f e, :volume_list, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappVolumeList::HUMAN) %>
+              <%= text_f e, :vfiler, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappVfiler::HUMAN) %>
+            </div>
+
+            <div class="netapp-vserver netapp-option">
+              <%= text_f e, :vserver, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappVserver::HUMAN) %>
+            </div>
+
+            <div class="netapp-eseries netapp-option hidden">
+              <%= text_f e, :controller_ips, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappControllerIps::HUMAN) %>
+              <%= text_f e, :sa_password, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappSaPassword::HUMAN) %>
+              <%= text_f e, :storage_pools, class: "cinder_netapp",
+                         label:      _(Staypuft::Deployment::CinderService::NetappStoragePools::HUMAN) %>
+            </div>
+          </div>


### PR DESCRIPTION
Enables a user to use NetApp storage systems as backends for Cinder.

I was able successfully create a deployment configuration with the new NetApp parameters, but my development environment wasn't able to actually complete any deployments.