### PR TITLE
BZ #1152516: Pass mac address to unused_ip

### DIFF
--- a/app/models/staypuft/interface_assigner.rb
+++ b/app/models/staypuft/interface_assigner.rb
@@ -151,7 +151,7 @@ module Staypuft
     end
 
     def suggest_ip(interface)
-      interface.ip = @subnet.unused_ip if interface.ip.blank?
+      interface.ip = @subnet.unused_ip(interface.mac) if interface.ip.blank?
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1152516

By passing mac address to unused_ip, it will make the proxy issue the
existing lease rather than a new one.
