### PR TITLE
BZ #1177740: Fix bond mode selection for multiple hosts

### DIFF
--- a/app/controllers/staypuft/bonds_controller.rb
+++ b/app/controllers/staypuft/bonds_controller.rb
@@ -92,7 +92,7 @@ module Staypuft
     end
 
     def find_hosts
-      @hosts = Host::Managed.where(:id => params[:host_ids]).includes(:interfaces)
+      @hosts = Host::Managed.where(:id => params[:host_ids].split(",").map(&:to_i)).includes(:interfaces)
       @host = @hosts.first
       @interfaces = @host.interfaces.where("type <> 'Nic::BMC'").order(:identifier).where(['(virtual = ? OR type = ?)', false, 'Nic::Bond'])
       @deployment = Deployment.find(params[:deployment_id])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1177740

This will also fix for the other operations (adding additional
interfaces, deleting interfaces, etc.). The list of hosts was not being
parsed properly. Therefore, only one of the hosts was being operated
upon. When the user went back into the settings, it would reset to
whatever setting the first host has, which may not have been what was
selected.