### PR TITLE
BZ #1179695: Make active-backup the default bonding mode

### DIFF
--- a/app/controllers/staypuft/bonds_controller.rb
+++ b/app/controllers/staypuft/bonds_controller.rb
@@ -18,7 +18,7 @@ module Staypuft
         params[:interfaces].each do |interface|
           bond.add_slave(interface)
         end
-        bond.mode = 'balance-tlb'
+        bond.mode = 'active-backup'
         bond.bond_options = 'miimon=100'
         bond.host = host
         @bonds.push bond


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1179695

Change the default bonding mode from balance-tlb to active-backup.