### PR TITLE
BZ #1179915 - nova-manage network create novanetwork called twice

### DIFF
--- a/app/lib/actions/staypuft/deployment/deploy.rb
+++ b/app/lib/actions/staypuft/deployment/deploy.rb
@@ -23,7 +23,7 @@ module Actions
 
           input.update id: deployment.id, name: deployment.name
           plan_action Hostgroup::OrderedDeploy,
-                      deployment.child_hostgroups.deploy_order.to_a,
+                      deployment.child_hostgroups.includes(:role).deploy_order.to_a,
                       hosts_to_deploy,
                       hosts_to_provision
           lock! deployment


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1179915

Compute nodes don't handle fully parallel deployment, one compute node
needs to be deployed on its own and then the rest can be deployed in
parallel.