### PR TITLE
BZ #1181327: Revert previous change_mode "fix", and fix properly

### DIFF
--- a/app/controllers/staypuft/bonds_controller.rb
+++ b/app/controllers/staypuft/bonds_controller.rb
@@ -92,7 +92,7 @@ module Staypuft
     end
 
     def find_hosts
-      @hosts = Host::Managed.where(:id => params[:host_ids].split(",").map(&:to_i)).includes(:interfaces)
+      @hosts = Host::Managed.where(:id => params[:host_ids]).includes(:interfaces)
       @host = @hosts.first
       @interfaces = @host.interfaces.where("type <> 'Nic::BMC'").order(:identifier).where(['(virtual = ? OR type = ?)', false, 'Nic::Bond'])
       @deployment = Deployment.find(params[:deployment_id])

--- a/app/views/staypuft/interfaces/_drop_zone.html.erb
+++ b/app/views/staypuft/interfaces/_drop_zone.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-default interface" id="<%= identifier %>-interface" data-interface="<%= identifier %>">
   <div class="panel-heading clearfix">
     <% if bond_mode %>
-      <div id="bonding_mode" class="dropdown pull-right" data-path="<%= change_mode_deployment_bond_path(:id => identifier) %>">
+        <div id="bonding_mode" class="dropdown pull-right" data-path="<%= change_mode_deployment_bond_path(:id => identifier, :host_ids => hosts.map(&:id)) %>">
         <%= _('Bonding Mode:') %>
         <button class="btn btn-default btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
           <%= bond_mode %>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1181327

The change_mode was not passing host_ids the same way as the rest of the
operations. This makes the change_mode call correct.