### PR TITLE
BZ #1180694: Initially disable glance when using ceph as a backend

### DIFF
--- a/app/assets/javascripts/staypuft/staypuft.js
+++ b/app/assets/javascripts/staypuft/staypuft.js
@@ -166,6 +166,12 @@ $('.neutron_ml2_mechanisms').parent().parent().removeClass('col-md-6').addClass(
       } else {
         $('.glance-controller-warning').hide();
       }
+      if($("#staypuft_deployment_glance_driver_backend_ceph").is(":checked")) {
+        $('.glance-ceph-warning').find(".replace").html(" (Ceph)");
+        $('.glance-ceph-warning').show();
+      } else {
+        $('.glance-ceph-warning').hide();
+      }
     }
     if(which_warning == "cinder") {
       if($("#staypuft_deployment_cinder_backend_lvm").is(":checked")) {

--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -267,6 +267,7 @@ module Staypuft
       neutron_network_device_mtu  = { :string => '<%= @host.deployment.neutron.compute_network_device_mtu %>' }
 
       # Glance
+      glance                      = { :string => '<%= @host.deployment.glance.ceph_backend? ? "false" : "true" %>'}
       backend                     = { :string => '<%= @host.deployment.glance.backend %>' }
       pcmk_fs_type                = { :string => '<%= @host.deployment.glance.pcmk_fs_type %>' }
       pcmk_fs_device              = { :string => '<%= @host.deployment.glance.pcmk_fs_device %>' }
@@ -409,6 +410,7 @@ module Staypuft
               'ceph_osd_journal_size'         => ceph_osd_journal_size,
               'cinder_db_password'            => cinder_db_pw,
               'cinder_user_password'          => cinder_user_pw,
+              'include_glance'                => glance,
               'glance_db_password'            => glance_db_pw,
               'glance_user_password'          => glance_user_pw,
               'heat_db_password'              => heat_db_pw,

--- a/app/models/staypuft/deployment/glance_service.rb
+++ b/app/models/staypuft/deployment/glance_service.rb
@@ -39,7 +39,7 @@ module Staypuft
 
     class Jail < Safemode::Jail
       allow :driver_backend, :pcmk_fs_type, :pcmk_fs_device, :pcmk_fs_options, :backend,
-            :pcmk_fs_manage
+            :pcmk_fs_manage, :ceph_backend?
     end
 
     def set_defaults

--- a/app/views/staypuft/steps/services_configuration.html.erb
+++ b/app/views/staypuft/steps/services_configuration.html.erb
@@ -29,6 +29,7 @@
             <div class="tab-pane" id="<%= service_name %>">
               <h3><%= _("%s Service Configuration") % service_name.to_s.capitalize %></h3>
               <div class="<%= "%s-controller-warning" % service_name.to_s %> alert alert-warning base in fade alert-dismissable hide"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button><h4 class="alert-heading"><%= _("Warning") %></h4><li><%= _("Only one controller should be assigned when using this option.") %><span class="replace"></span></li></div>
+              <div class="<%= "%s-ceph-warning" % service_name.to_s %> alert alert-warning base in fade alert-dismissable hide"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">x</button><h4 class="alert-heading"><%= _("Warning") %></h4><li><%= _("Manual steps are required when deploying with Ceph as a backend for #{service_name.to_s}. Please see documentation for additional steps.") %><span class="replace"></span></li></div>
               <%= render partial: service_name.to_s, locals: {f: f}%>
             </div>
             <% end %>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180694

When Ceph is selected as the backend for glance, this code does a number
of things:

1. The seeder now uses glance_service.ceph_backend? to set the
include_glance param
2. It puts up a message warning the user that manual steps are required.
3. The user would then override the advanced config to make
include_glance explicitly 'true' and get rid of the dynamic param.