### PR TITLE
Dropping hard request on discovery gem

### DIFF
--- a/staypuft.gemspec
+++ b/staypuft.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'wicked'
   s.add_dependency 'deface'
 
-  s.add_dependency 'foreman_discovery', '~> 1.4.0.rc1'
+  s.add_dependency 'foreman_discovery'
   s.add_dependency 'ipaddress'
 end


### PR DESCRIPTION
We are releasing Discovery 2.0 and Staypuft insist on 1.4 version. I'd
recommend to go either for `> 1.4.0` (which gives a warning for me) or drop the
version number completely.

This blocks us from the release, can I ask you for a quick minor version?

Thank you