### PR TITLE
Related to BZ#1184633 - report errors from 1st and 2nd attempt too

### DIFF
--- a/app/lib/actions/staypuft/host/puppet_run.rb
+++ b/app/lib/actions/staypuft/host/puppet_run.rb
@@ -31,6 +31,7 @@ module Actions
           while !result && tries < 3
             result = host.puppetrun!
             tries += 1
+            output[:errors] = host.errors.full_messages unless result
           end
 
           # we need executed_at for both success and failure cases
@@ -40,7 +41,6 @@ module Actions
           output[:result] = result
 
           unless result
-            output[:errors] = host.errors.full_messages
             fail(::Staypuft::Exception, "Puppet run failed for host: #{host.id}")
           end
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1184633

Previously PuppetRun errors were visible in dynflow console only if the
PuppetRun action failed because of them. Now the errors will be saved
anytime an attempt fails, even if a later attempt succeeds.