### PR TITLE
BZ#1180322 - registration puppet run reports errors

### DIFF
--- a/app/lib/actions/staypuft/host/trigger_provisioning.rb
+++ b/app/lib/actions/staypuft/host/trigger_provisioning.rb
@@ -20,9 +20,12 @@ module Actions
         def plan(host)
           fail 'cannot provision unmanaged host' unless host.managed?
 
-          # return back to hostgroup's environment
           sequence do
-            plan_action Actions::Staypuft::Host::Update, host, :environment => nil
+            # set the env to 'provisioning' to avoid compiling the
+            # production catalog when actually not applying it, which
+            # might cause errors
+            plan_action Actions::Staypuft::Host::Update, host,
+                        :environment_id => Environment.get_or_create_provisioning.id
             plan_self host_id: host.id
           end
         end

--- a/app/models/staypuft/concerns/environment_extensions.rb
+++ b/app/models/staypuft/concerns/environment_extensions.rb
@@ -8,5 +8,9 @@ module Staypuft::Concerns::EnvironmentExtensions
                 'missing discovery environment, which ensures all its machines are booted ' +
                     'to discovery image.'
     end
+
+    def get_or_create_provisioning
+      where(name: 'provisioning').first_or_create
+    end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1180322

Even though the client registration Puppet run doesn't apply any
changes, it still attempts to compile the full host's Puppet catalog and
may cause errors. Switching it to an empty environment will exclude the
Puppet classes from the YAML description of the node and cause the
catalog to be empty and without errors.