### PR TITLE
Minor issue with CSS label not clearing left

### DIFF
--- a/app/assets/stylesheets/staypuft/staypuft.css.scss
+++ b/app/assets/stylesheets/staypuft/staypuft.css.scss
@@ -217,6 +217,7 @@ h3[data-toggle="collapse"] {
     margin-bottom: 0;
     .control-label {
       text-align: left;
+      clear: left;
     }
     .help-block {
       margin-bottom: 0;


### PR DESCRIPTION
![](https://s3.amazonaws.com/f.cl.ly/items/2F050B030z0l2V123b0y/Screen%20Shot%202015-02-06%20at%202.42.30%20PM.png)
versus with this fix:
![](https://s3.amazonaws.com/f.cl.ly/items/300v1N1e0K3b2Z0X2G3Q/Screen%20Shot%202015-02-06%20at%202.42.57%20PM.png)