### PR TITLE
BZ #1192152: Netapp compute method names were incorrect

### DIFF
--- a/app/models/staypuft/deployment/cinder_service.rb
+++ b/app/models/staypuft/deployment/cinder_service.rb
@@ -202,12 +202,21 @@ module Staypuft
       end
     end
 
-    %w{hostname login password server_port storage_familie transport_type storage_protocol
-        nfs_share nfs_shares_config volume_list vfiler vserver controller_ip sa_password 
-        storage_pool }.each do |name|
+    %w{hostname login password server_port transport_type storage_protocol
+        nfs_shares_config volume_list vfiler vserver sa_password }.each do |name|
       define_method "compute_netapp_#{name}s" do
         self.netapps.collect { |e| e.send name }
       end
+    end
+
+    %w{controller_ips nfs_shares storage_pools}.each do |name|
+      define_method "compute_netapp_#{name}" do
+        self.netapps.collect { |e| e.send name }
+      end
+    end
+
+    def compute_netapp_storage_families
+      self.netapps.collect { |e| e.send :storage_family }
     end
 
     private


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1192152

Some of the netapp compute_* methods had different names and had to be
handle in a different way.