### PR TITLE
Staypuft-NetApp fixes

### DIFF
--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -323,7 +323,7 @@ module Staypuft
       cinder_netapp_login             = { :array => '<%= @host.deployment.cinder.compute_netapp_logins %>' }
       cinder_netapp_password          = { :array => '<%= @host.deployment.cinder.compute_netapp_passwords %>' }
       cinder_netapp_server_port       = { :array => '<%= @host.deployment.cinder.compute_netapp_server_ports %>' }
-      cinder_netapp_storage_family    = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_families %>' }
+      cinder_netapp_storage_family    = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_familys %>' }
       cinder_netapp_transport_type    = { :array => '<%= @host.deployment.cinder.compute_netapp_transport_types %>' }
       cinder_netapp_storage_protocol  = { :array => '<%= @host.deployment.cinder.compute_netapp_storage_protocols %>' }
       cinder_netapp_nfs_shares        = { :array => '<%= @host.deployment.cinder.compute_netapp_nfs_shares %>' }

--- a/app/models/staypuft/deployment/cinder_service/netapp.rb
+++ b/app/models/staypuft/deployment/cinder_service/netapp.rb
@@ -19,11 +19,11 @@ module Staypuft
 
     def initialize(attrs = {})
       @errors = ActiveModel::Errors.new(self)
-      self.attributes = attrs
       self.server_port = 80
       self.storage_family = 'ontap_cluster'
       self.transport_type = 'http'
       self.storage_protocol = 'nfs'
+      self.attributes = attrs
     end
 
     def self.human_attribute_name(attr, options = {})


### PR DESCRIPTION
This change fixes a few things:
  1. Change storage_families param to storage_familys. No need
     to complicate the code because of English grammar.
  2. Split nfs_shares param by comma to an array because this
     is what puppet-cinder expects