### PR TITLE
BZ #1188602: Ensure bonds have a mac address

### DIFF
--- a/app/models/staypuft/concerns/nic_bonding_extensions.rb
+++ b/app/models/staypuft/concerns/nic_bonding_extensions.rb
@@ -1,0 +1,17 @@
+module Staypuft
+  module Concerns
+    module NicBondingExtensions
+      extend ActiveSupport::Concern
+
+      included do
+        before_save :ensure_mac
+      end
+
+      def ensure_mac
+        mac_addresses = self.host.interfaces.where(
+            :identifier => attached_devices_identifiers).pluck(:mac).compact
+        self.mac =  mac_addresses.first unless mac_addresses.include?(self.mac)
+      end
+    end
+  end
+end

--- a/lib/staypuft/engine.rb
+++ b/lib/staypuft/engine.rb
@@ -43,6 +43,7 @@ module Staypuft
       ::Api::V1::HostsController.send :include, Staypuft::Concerns::HostsApiExtensions
       ::Api::V2::HostsController.send :include, Staypuft::Concerns::HostsApiExtensions
       ::HostsController.send :include, Staypuft::Concerns::HostsControllerExtensions
+      ::Nic::Bond.send :include, Staypuft::Concerns::NicBondingExtensions
 
       # preload all the Foreman's lib files but only in production
       if Rails.env.production?


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1188602

Changes to bonds will not save without a mac address. This will set the
mac address to the first interface in the bond.