### PR TITLE
BZ #1221018: Account for tenant network on primary interface

### DIFF
--- a/app/lib/staypuft/network_query.rb
+++ b/app/lib/staypuft/network_query.rb
@@ -64,15 +64,20 @@ module Staypuft
         Staypuft::SubnetType::TENANT, host)
       return [] if interface_hash.empty?
       subnet = interface_hash[:subnet]
-      top_level_interface = host.interfaces.where(
-        identifier: interface_hash[:interface]).first
-      interfaces = [top_level_interface.identifier]
-      if subnet && subnet.has_vlanid?
-        next_interface = host.interfaces.where(identifier:
-          top_level_interface.attached_to).first
-        interfaces << next_interface.identifier
-        if next_interface.is_a? Nic::Bond
-          interfaces << next_interface.attached_devices_identifiers
+      interfaces = []
+      if interface_hash[:interface] == host.primary_interface
+        interfaces << host.primary_interface
+      else
+        top_level_interface = host.interfaces.where(
+          identifier: interface_hash[:interface]).first
+        interfaces << top_level_interface.identifier
+        if subnet && subnet.has_vlanid? && top_level_interface
+          next_interface = host.interfaces.where(identifier:
+            top_level_interface.attached_to).first
+          interfaces << next_interface.identifier
+          if next_interface.is_a? Nic::Bond
+            interfaces << next_interface.attached_devices_identifiers
+          end
         end
       end
       interfaces.flatten


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1221018

Because of the way Foreman handles the primary interface, and when
the tenant network is on that interface, with no bond or vlan involved,
it would cause an exception.