### PR TITLE
Add checkbox for cisco n1kv and boxes for vsm info

### DIFF
--- a/app/assets/javascripts/staypuft/staypuft.js
+++ b/app/assets/javascripts/staypuft/staypuft.js
@@ -302,6 +302,18 @@ $('.neutron_ml2_mechanisms').parent().parent().removeClass('col-md-6').addClass(
     }
   }
 
+  showNeutronMl2CiscoN1kv();
+  $("#staypuft_deployment_neutron_ml2_cisco_n1kv").change(showNeutronMl2CiscoN1kv);
+  function showNeutronMl2CiscoN1kv() {
+    if ($('#staypuft_deployment_neutron_ml2_cisco_n1kv').is(":checked")) {
+      $('#staypuft_deployment_neutron_ml2_cisco_n1kv').parent().after($('.neutron_cisco_n1kv'));
+      $('.neutron_cisco_n1kv').fadeIn(duration);
+    }
+    else {
+      $('.neutron_cisco_n1kv').fadeOut(duration);
+    }
+  }
+
   showCephNotification();
   function showCephNotification() {
     var cephDeploymentNotification = readFromCookie();

--- a/app/lib/staypuft/seeder.rb
+++ b/app/lib/staypuft/seeder.rb
@@ -411,8 +411,8 @@ module Staypuft
       cisco_nexus_config             = { :hash => '<%= n = @host.deployment.neutron; (n.active? && n.cisco_nexus_mechanism?) ? n.compute_cisco_nexus_config : {} %>' }
 
       # Cisco N1KV params
-      n1kv_vsm_ip                    = { :string => '<%= n = @host.deployment.neutron; (n.active? && n.n1kv_plugin?) ? n.n1kv_vsm_ip : "" %>' }
-      n1kv_vsm_password              = { :string => '<%= n = @host.deployment.neutron; (n.active? && n.n1kv_plugin?) ? n.n1kv_vsm_password : "" %>' }
+      n1kv_vsm_ip                    = { :string => '<%= n = @host.deployment.neutron; (n.active? && (n.n1kv_plugin? || n.cisco_n1kv_mechanism?)) ? n.n1kv_vsm_ip : "" %>' }
+      n1kv_vsm_password              = { :string => '<%= n = @host.deployment.neutron; (n.active? && (n.n1kv_plugin? || n.cisco_n1kv_mechanism?)) ? n.n1kv_vsm_password : "" %>' }
       n1kv_plugin_additional_params  = { :hash => { 'default_policy_profile' => 'default-pp',
                                                     'network_node_policy_profile' => 'default-pp',
                                                     'poll_duration' => '10',

--- a/app/models/staypuft/deployment/neutron_service.rb
+++ b/app/models/staypuft/deployment/neutron_service.rb
@@ -6,7 +6,7 @@ module Staypuft
 
     SEGMENTATION_LIST   = ['vxlan', 'vlan', 'gre']
     VLAN_HELP           = N_('[1-4094] (e.g. 10:15)')
-    ML2MECHANISM_TYPES  = :ml2_openvswitch, :ml2_l2population, :ml2_cisco_nexus
+    ML2MECHANISM_TYPES  = :ml2_openvswitch, :ml2_l2population, :ml2_cisco_nexus, :ml2_cisco_n1kv
     N1KV_PARAMS         = :n1kv_vsm_ip, :n1kv_vsm_password
 
     param_attr :network_segmentation, :tenant_vlan_ranges, :core_plugin, :network_device_mtu,
@@ -69,9 +69,11 @@ module Staypuft
       OPENVSWITCH = 'openvswitch'
       L2POPULATION = 'l2population'
       CISCO_NEXUS = 'cisco_nexus'
+      CISCO_N1KV = 'cisco_n1kv'
       LABELS = { OPENVSWITCH => N_('Open vSwitch'),
                  L2POPULATION => N_('L2 Population'),
-                 CISCO_NEXUS => N_('Cisco Nexus') }
+                 CISCO_NEXUS => N_('Cisco Nexus'),
+                 CISCO_N1KV  => N_('Cisco N1KV')}
       TYPES = LABELS.keys
       HUMAN = N_('ML2 Mechanism Drivers')
     end
@@ -100,7 +102,7 @@ module Staypuft
       allow :networker_vlan_ranges, :compute_vlan_ranges, :network_segmentation, :enable_tunneling?,
         :tenant_iface, :networker_ovs_bridge_mappings, :networker_ovs_bridge_uplinks,
         :compute_ovs_bridge_mappings, :compute_ovs_bridge_uplinks, :ovs_tunnel_types,
-        :openvswitch_mechanism?, :l2population_mechanism?, :cisco_nexus_mechanism?,
+        :openvswitch_mechanism?, :l2population_mechanism?, :cisco_nexus_mechanism?, :cisco_n1kv_mechanism?,
         :ml2_mechanisms, :nexuses, :active?, :compute_cisco_nexus_config, :core_plugin,
         :ml2_plugin?, :n1kv_plugin?, :n1kv_vsm_ip, :n1kv_vsm_password,
         :core_plugin_module, :network_device_mtu, :compute_network_device_mtu, :l3_ha
@@ -112,6 +114,7 @@ module Staypuft
       self.ml2_openvswitch = "true"
       self.ml2_l2population = "false"
       self.ml2_cisco_nexus = "false"
+      self.ml2_cisco_n1kv = "false"
       self.network_device_mtu = nil
     end
 
@@ -188,6 +191,10 @@ module Staypuft
       self.ml2_cisco_nexus == "true"
     end
 
+    def cisco_n1kv_mechanism?
+      self.ml2_cisco_n1kv == "true"
+    end
+
     def ml2_plugin?
       self.core_plugin == CorePlugin::ML2
     end
@@ -219,6 +226,7 @@ module Staypuft
         'ml2_openvswitch'            => ml2_openvswitch,
         'ml2_l2population'           => ml2_l2population,
         'ml2_cisco_nexus'            => ml2_cisco_nexus,
+        'ml2_cisco_n1kv'             => ml2_cisco_n1kv,
         'nexuses'                    => nexuses,
         'n1kv_vsm_ip'                => n1kv_vsm_ip,
         'n1kv_vsm_password'          => n1kv_vsm_password }

--- a/app/views/staypuft/steps/_neutron.html.erb
+++ b/app/views/staypuft/steps/_neutron.html.erb
@@ -48,6 +48,13 @@
                                :checked         => @deployment.neutron.cisco_nexus_mechanism?,
                                :text            => _(Staypuft::Deployment::NeutronService::Ml2Mechanisms::LABELS['cisco_nexus']))
     %>
+    <%= check_box_f_non_inline(p, :ml2_cisco_n1kv,
+                               :checked_value   => 'true',
+                               :unchecked_value => 'false',
+                               :checked         => @deployment.neutron.cisco_n1kv_mechanism?,
+                               :text            => _(Staypuft::Deployment::NeutronService::Ml2Mechanisms::LABELS['cisco_n1kv']))
+    %>
+
   </div>
 
   <div class="neutron_n1kv_parameters inset_form hide">
@@ -67,6 +74,11 @@
       <%= p.fields_for 'nexuses[]', Staypuft::Deployment::NeutronService::Cisconexus.new, index: 'NEW_RECORD' do |e| render(partial: 'neutron_cisco_nexus_form', locals: {e: e}); end %>
     </script>
     <button type="button" class= "btn btn-primary btn-sm add_another_switch"><%= _("Add Another Switch") %></button> 
+  </div>
+
+  <div class="neutron_cisco_n1kv inset_form hide">
+    <%= change_label_width 4, text_f(p, :n1kv_vsm_ip, class: "neutron_n1kv_vsm_ip", label: _('VSM IP')) %>
+    <%= change_label_width 4, text_f(p, :n1kv_vsm_password, class: "neutron_n1kv_vsm_password", label: _('VSM Password')) %>
   </div>
 
 <% end %>


### PR DESCRIPTION
While creating a deployment, users can now select Cisco N1Kv
as an ML2 mech driver option. Checking the Cisco N1Kv option
would bring up text boxes that would accept values for N1Kv
VSM IP and password.

BZ# 1250271: Cisco Nexus 1000V does not show up among ML2 drivers
while creating deployment

https://bugzilla.redhat.com/show_bug.cgi?id=1250271