### PR TITLE
Removing options for configuring n1kv core plugin

### DIFF
--- a/app/assets/javascripts/staypuft/staypuft.js
+++ b/app/assets/javascripts/staypuft/staypuft.js
@@ -127,17 +127,6 @@ $('.neutron_ml2_mechanisms').parent().parent().removeClass('col-md-6').addClass(
     }
   }
 
-  showNeutronN1kvParameters();
-  $("input[name='staypuft_deployment[neutron][core_plugin]']").change(showNeutronN1kvParameters);
-  function showNeutronN1kvParameters() {
-    $('#staypuft_deployment_neutron_core_plugin_n1kv').parent().parent().parent().removeClass('col-md-4').addClass('col-md-6')
-    if ($('#staypuft_deployment_neutron_core_plugin_n1kv').is(":checked")) {
-      $('#staypuft_deployment_neutron_core_plugin_n1kv').parent().after($('.neutron_n1kv_parameters'));
-      $('.neutron_n1kv_parameters').fadeIn(duration);
-    } else {
-      $('.neutron_n1kv_parameters').fadeOut(duration);
-    }
-  }
 
   showNeutronExternalInterface();
   $("input[name='staypuft_deployment[neutron][use_external_interface]']").change(showNeutronExternalInterface);

--- a/app/views/staypuft/steps/_neutron.html.erb
+++ b/app/views/staypuft/steps/_neutron.html.erb
@@ -57,11 +57,6 @@
 
   </div>
 
-  <div class="neutron_n1kv_parameters inset_form hide">
-    <%= change_label_width 4, text_f(p, :n1kv_vsm_ip, class: "neutron_n1kv_vsm_ip", label: _('VSM IP')) %>
-    <%= change_label_width 4, text_f(p, :n1kv_vsm_password, class: "neutron_n1kv_vsm_password", label: _('VSM Password')) %>
-  </div>
-
   <div class="neutron_cisco_nexus col-md-offset-1 hide">
     <div id="nexuses" class="neutron_nexus_picker">
       <% @deployment.neutron.nexuses.each_with_index do |nexus, index| %>


### PR DESCRIPTION
Since n1kv core plugin was replaced by the ML2 plugin,
core plugin parameters should not be included in the
javascript. Their presence conflicts with vsm admin and
password variables also being used by ML2 options.

BZ# 1285129 - N1KV ML2 VSM IP and password not properly
propagated from deployment wizard

https://bugzilla.redhat.com/show_bug.cgi?id=1285129
